### PR TITLE
Ensure feed handler always reveals taskpane

### DIFF
--- a/packages/excel/src/taskpane/Taskpane.test.ts
+++ b/packages/excel/src/taskpane/Taskpane.test.ts
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals';
+
+describe('openFeedHandler', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        (global as any).Office = {
+            onReady: jest.fn().mockReturnValue({ then: jest.fn() }),
+            addin: {
+                setStartupBehavior: jest.fn(),
+                showAsTaskpane: jest.fn(),
+            },
+            StartupBehavior: { load: 'load' },
+            actions: { associate: jest.fn() },
+        };
+        (global as any).document = { getElementById: jest.fn().mockReturnValue({}) };
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        // cleanup globals
+        delete (global as any).Office;
+        delete (global as any).document;
+    });
+
+    it('shows the taskpane for consecutive invocations', async () => {
+        const { openFeedHandler } = await import('./Taskpane');
+        const event = { completed: jest.fn() };
+
+        openFeedHandler(event);
+        jest.advanceTimersByTime(60);
+
+        openFeedHandler(event);
+        jest.advanceTimersByTime(60);
+
+        const show = (global as any).Office.addin.showAsTaskpane;
+        expect(show).toHaveBeenCalledTimes(2);
+        expect(event.completed).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/excel/src/taskpane/Taskpane.tsx
+++ b/packages/excel/src/taskpane/Taskpane.tsx
@@ -131,8 +131,9 @@ Office.onReady().then(() => {
 
 export function openSettingsHandler(event?: unknown) {
     taskpaneApi.goToView('settings');
+    Office.addin.showAsTaskpane();
     if (canComplete(event)) {
-        event.completed();
+        setTimeout(() => event.completed(), 50);
     }
 }
 Office.actions.associate('openSettingsHandler', openSettingsHandler);
@@ -151,8 +152,9 @@ function canComplete(event: unknown): event is CanComplete {
 
 export function openFeedHandler(event?: unknown) {
     taskpaneApi.goToView('feed');
+    Office.addin.showAsTaskpane();
     if (canComplete(event)) {
-        event.completed();
+        setTimeout(() => event.completed(), 50);
     }
 }
 Office.actions.associate('openFeedHandler', openFeedHandler);


### PR DESCRIPTION
## Summary
- always show the taskpane when invoking ribbon handlers
- delay command completion to ensure UI refresh
- add regression test for consecutive feed openings

## Testing
- `bun run lint` *(fails: No files matching the pattern "src/**/*.{ts}")*
- `bun run test` *(fails: 1 failed, 3 passed)*
- `bun run build` *(fails: TS6059: File ... is not under 'rootDir')*

------
https://chatgpt.com/codex/tasks/task_b_6877561ecc208329a6714b2e8c9910b4