### PR TITLE
Add start button and help modal

### DIFF
--- a/packages/excel/manifest.xml
+++ b/packages/excel/manifest.xml
@@ -430,7 +430,7 @@
                 <bt:String id="HomePulseGroup.Label"
                            DefaultValue="Pulse" />
                 <bt:String id="HomePulseStartButton.Label"
-                           DefaultValue="Settings" />
+                           DefaultValue="Start" />
                 <bt:String id="FeedButton.Label"
                            DefaultValue="Feed" />
                 <!-- Label for Analyze Sentiment button on Home tab -->

--- a/packages/excel/src/services/connectHelp.ts
+++ b/packages/excel/src/services/connectHelp.ts
@@ -1,0 +1,25 @@
+import { getRelativeUrl } from './relativeUrl';
+
+export function showConnectHelpDialog(): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const url = getRelativeUrl('ConnectHelpDialog.html');
+        Office.context.ui.displayDialogAsync(
+            url,
+            { height: 30, width: 20, displayInIframe: true },
+            (result) => {
+                if (result.status === Office.AsyncResultStatus.Failed) {
+                    reject(result.error);
+                } else {
+                    const dialog = result.value;
+                    dialog.addEventHandler(
+                        Office.EventType.DialogMessageReceived,
+                        () => {
+                            dialog.close();
+                            resolve();
+                        },
+                    );
+                }
+            },
+        );
+    });
+}

--- a/packages/excel/src/services/ribbon.ts
+++ b/packages/excel/src/services/ribbon.ts
@@ -81,3 +81,24 @@ export function disableRibbonButtons() {
         ],
     });
 }
+
+export function updateHomeStartButtonLabel(label: string) {
+    Office.ribbon.requestUpdate({
+        tabs: [
+            {
+                id: 'TabPulse',
+                groups: [
+                    {
+                        id: 'PulseGroup',
+                        controls: [
+                            {
+                                id: 'HomePulseStartButton',
+                                label,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    });
+}

--- a/packages/excel/src/taskpane/ConnectHelpDialog.html
+++ b/packages/excel/src/taskpane/ConnectHelpDialog.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
+    <title>Getting Started</title>
+  </head>
+  <body style="font-family:'Segoe UI', sans-serif; margin:20px;">
+    <p>Enter your email address and click <strong>Start</strong>. A browser window will open so you can sign in. After completing authentication, return to Excel.</p>
+    <div style="margin-top:16px; text-align:right;">
+      <button id="okBtn">OK</button>
+    </div>
+    <script>
+      document.getElementById('okBtn').addEventListener('click', function () {
+        Office.context.ui.messageParent('ok');
+      });
+    </script>
+  </body>
+</html>

--- a/packages/excel/src/taskpane/Taskpane.tsx
+++ b/packages/excel/src/taskpane/Taskpane.tsx
@@ -19,9 +19,11 @@ function checkForLogin(success?: () => void, failure?: () => void) {
     const orgId = sessionStorage.getItem('org-id');
     if (token && email && orgId) {
         Ribbon.enableRibbonButtons();
+        Ribbon.updateHomeStartButtonLabel('Settings');
         success?.();
     } else {
         Ribbon.disableRibbonButtons();
+        Ribbon.updateHomeStartButtonLabel('Start');
         failure?.();
     }
 }

--- a/packages/excel/src/taskpane/Unauthenticated.tsx
+++ b/packages/excel/src/taskpane/Unauthenticated.tsx
@@ -1,6 +1,6 @@
 import { PrimaryButton, DefaultButton, TextField } from '@fluentui/react';
 import type { TaskpaneApi } from './api';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 // Import company logo via webpack asset module for correct path resolution
 import logo from '../../assets/logo-filled.png';
 import { findOrganization } from 'pulse-common/org';
@@ -8,6 +8,7 @@ import { setupExcelPKCEAuth } from './pkceAuth';
 import { getAccessToken, signIn } from 'pulse-common/auth';
 import { configureClient } from 'pulse-common/api';
 import { getRelativeUrl } from '../services/relativeUrl';
+import { showConnectHelpDialog } from '../services/connectHelp';
 
 interface Props {
     api: TaskpaneApi;
@@ -16,6 +17,10 @@ interface Props {
 export function Unauthenticated({ setEmail: setAppEmail }: Props) {
     const [connecting, setConnecting] = useState(false);
     const [email, setEmail] = useState('');
+
+    useEffect(() => {
+        showConnectHelpDialog().catch((e) => console.error(e));
+    }, []);
     // Registration URL opens in browser for new users
     const handleRegister = useCallback(() => {
         const url = 'https://researchwiseai.com/register';
@@ -129,9 +134,9 @@ export function Unauthenticated({ setEmail: setAppEmail }: Props) {
                     <PrimaryButton
                         disabled={connecting}
                         onClick={() => clickConnect(email)}
-                        id="connect"
+                        id="start"
                     >
-                        {connecting ? 'Connecting...' : 'Connect'}
+                        {connecting ? 'Connecting...' : 'Start'}
                     </PrimaryButton>
                     <DefaultButton id="register" onClick={handleRegister}>
                         Register

--- a/packages/excel/webpack.config.js
+++ b/packages/excel/webpack.config.js
@@ -152,6 +152,12 @@ module.exports = async (env, options) => {
                 template: './src/taskpane/AllocationModeDialog.html',
                 inject: false,
             }),
+            // Dialog explaining how to connect
+            new HtmlWebpackPlugin({
+                filename: 'ConnectHelpDialog.html',
+                template: './src/taskpane/ConnectHelpDialog.html',
+                inject: false,
+            }),
             // Dialog for modals
             new HtmlWebpackPlugin({
                 filename: 'Modal.html',


### PR DESCRIPTION
## Summary
- add `showConnectHelpDialog` utility
- display modal on the unauthenticated page
- show **Start** button in UI and on the ribbon
- update ribbon handling to switch between *Start* and *Settings*
- package new `ConnectHelpDialog` in webpack
- adjust manifest default label for home button

## Testing
- `bun run --filter '*' lint` *(fails: no files matching pattern, etc.)*
- `bun run --filter '*' test` *(fails: 3 tests failed in pulse-common)*
- `bun run --filter '*' build` *(fails: build errors in sheets and common packages)*

------
https://chatgpt.com/codex/tasks/task_b_687756c832e483299974b63852b4ea7a