### PR TITLE
Refactor input loading to skip unused rows

### DIFF
--- a/packages/excel/src/flows/splitIntoSentences.ts
+++ b/packages/excel/src/flows/splitIntoSentences.ts
@@ -23,7 +23,7 @@ export async function splitIntoSentencesFlow(
     );
     const maxSentences = Math.max(...sentences.map((s) => s.length));
     const result = Array.from({ length: maxSentences }, () =>
-        Array.from({ length: inputs.length }, () => ''),
+        Array.from({ length: positions.length }, () => ''),
     );
 
     console.log('sentences', sentences);

--- a/packages/excel/src/services/__tests__/flows-preserve-rows.test.ts
+++ b/packages/excel/src/services/__tests__/flows-preserve-rows.test.ts
@@ -1,0 +1,44 @@
+import { countWordsFlow } from '../../flows/countWords';
+import { getSheetInputsAndPositions } from '../getSheetInputsAndPositions';
+
+jest.mock('../getSheetInputsAndPositions');
+
+jest.mock('wink-nlp', () => {
+    return () => ({
+        readDoc: (text: string) => ({
+            tokens: () => ({
+                out: () => text.split(/\s+/).filter(Boolean),
+            }),
+        }),
+    });
+});
+jest.mock('wink-eng-lite-web-model', () => ({}));
+
+describe('flows writing', () => {
+    it('preserves empty rows when writing results', async () => {
+        const cellMocks: any[] = [];
+        const sheet = {
+            getCell: jest.fn((r: number, c: number) => {
+                const cell = { values: undefined };
+                cellMocks.push({ r, c, cell });
+                return cell;
+            }),
+        } as any;
+        (getSheetInputsAndPositions as jest.Mock).mockResolvedValue({
+            inputs: ['one two', 'three'],
+            positions: [
+                { row: 1, col: 1 }, // row 1
+                { row: 3, col: 1 }, // row 3 (row 2 empty)
+            ],
+            sheet,
+        });
+
+        const context = { sync: jest.fn().mockResolvedValue(undefined) } as any;
+        await countWordsFlow(context, 'A:A');
+
+        expect(cellMocks[0].r).toBe(0);
+        expect(cellMocks[1].r).toBe(2);
+        expect(cellMocks[0].cell.values).toEqual([[2]]);
+        expect(cellMocks[1].cell.values).toEqual([[1]]);
+    });
+});

--- a/packages/excel/src/services/__tests__/getSheetInputsAndPositions.test.ts
+++ b/packages/excel/src/services/__tests__/getSheetInputsAndPositions.test.ts
@@ -1,0 +1,65 @@
+import { getSheetInputsAndPositions } from '../getSheetInputsAndPositions';
+
+/** Mocks for basic Excel range objects */
+interface MockRange {
+    rowIndex: number;
+    columnIndex: number;
+    rowCount: number;
+    columnCount: number;
+    values?: any[][];
+    load: jest.Mock;
+    getIntersectionOrNullObject?: (other: MockRange) => MockRange & { isNullObject?: boolean };
+}
+
+function createRange(props: Partial<MockRange> = {}): MockRange {
+    return {
+        rowIndex: 0,
+        columnIndex: 0,
+        rowCount: 1,
+        columnCount: 1,
+        load: jest.fn(),
+        ...props,
+    } as MockRange;
+}
+
+describe('getSheetInputsAndPositions', () => {
+    it('returns positions using used range intersection for column selection', async () => {
+        const values = [['foo'], [null], ['bar']];
+
+        const intersection = createRange({
+            rowIndex: 0,
+            columnIndex: 0,
+            rowCount: values.length,
+            columnCount: 1,
+            values,
+        }) as MockRange & { isNullObject?: boolean };
+        intersection.isNullObject = false;
+
+        const target = createRange({
+            getIntersectionOrNullObject: jest.fn(() => intersection),
+        });
+
+        const sheet = {
+            getRange: jest.fn(() => target),
+            getUsedRange: jest.fn(() => createRange()),
+            getRangeByIndexes: jest.fn(() => createRange({ values })),
+        } as any;
+
+        const context = {
+            workbook: {
+                worksheets: {
+                    getActiveWorksheet: jest.fn(() => sheet),
+                },
+            },
+            sync: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        const { inputs, positions } = await getSheetInputsAndPositions(context, 'A:A');
+        expect(target.getIntersectionOrNullObject).toHaveBeenCalled();
+        expect(inputs).toEqual(['foo', 'bar']);
+        expect(positions).toEqual([
+            { row: 1, col: 1 },
+            { row: 3, col: 1 },
+        ]);
+    });
+});

--- a/packages/excel/src/services/getSheetInputsAndPositions.ts
+++ b/packages/excel/src/services/getSheetInputsAndPositions.ts
@@ -32,13 +32,20 @@ export async function getSheetInputsAndPositions(
     }
 
     const target = sheet.getRange(rangeNotation);
-    target.load(['rowIndex', 'columnIndex', 'rowCount', 'columnCount']);
+    const used = sheet.getUsedRange();
+    const intersection = target.getIntersectionOrNullObject(used);
+    intersection.load(['rowIndex', 'columnIndex', 'rowCount', 'columnCount']);
 
     await context.sync();
 
+    if (intersection.isNullObject) {
+        console.error('Selected range contains no used cells');
+        throw new Error('No text found in selected data range');
+    }
+
     const batchSize = 1000;
     const values: any[][] = [];
-    const { rowIndex, columnIndex, rowCount, columnCount } = target;
+    const { rowIndex, columnIndex, rowCount, columnCount } = intersection;
 
     for (let rowStart = 0; rowStart < rowCount; rowStart += batchSize) {
         const rowEnd = Math.min(rowStart + batchSize, rowCount);


### PR DESCRIPTION
## Summary
- intersect selection with used range when reading inputs
- rely on position length when preallocating result array
- test column intersection row indexing
- test flows preserve empty rows

## Testing
- `bun run lint` *(fails: no files matching pattern / sessionStorage not defined)*
- `bun run test` *(fails: ThemeSet management tests fail)*
- `bun run build` *(fails: TS6059 file outside rootDir)*

------
https://chatgpt.com/codex/tasks/task_b_687756f6c1488329a76ad19fa92fab04