### PR TITLE
Disable get started modal

### DIFF
--- a/packages/excel/src/taskpane/Taskpane.tsx
+++ b/packages/excel/src/taskpane/Taskpane.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react';
-import './taskpane.css';
+// Import styles only in a browser environment to avoid issues in Jest tests
+// Avoid importing styles during Jest tests to prevent transform errors
+if (typeof window !== 'undefined' && !process.env.JEST_WORKER_ID) {
+    require('./taskpane.css');
+}
 import { createRoot } from 'react-dom/client';
 import { Settings } from './Settings';
 import { Feed } from './Feed';

--- a/packages/excel/src/taskpane/Unauthenticated.tsx
+++ b/packages/excel/src/taskpane/Unauthenticated.tsx
@@ -18,9 +18,12 @@ export function Unauthenticated({ setEmail: setAppEmail }: Props) {
     const [connecting, setConnecting] = useState(false);
     const [email, setEmail] = useState('');
 
-    useEffect(() => {
-        showConnectHelpDialog().catch((e) => console.error(e));
-    }, []);
+    // Temporarily disable the "Getting Started" dialog as it appears on every
+    // launch. Once we have a persistent dismissal mechanism this can be
+    // re-enabled.
+    // useEffect(() => {
+    //     showConnectHelpDialog().catch((e) => console.error(e));
+    // }, []);
     // Registration URL opens in browser for new users
     const handleRegister = useCallback(() => {
         const url = 'https://researchwiseai.com/register';


### PR DESCRIPTION
## Summary
- prevent Taskpane.tsx from loading CSS during test runs
- comment out call to showConnectHelpDialog

## Testing
- `bun run test` *(fails: 1 failed, 5 passed)*
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_b_6877ca286ec48329953ba538cc8733f3