### PR TITLE
Ensure Excel flows output to new sheet

### DIFF
--- a/packages/excel/src/flows/allocateThemesAutomatic.ts
+++ b/packages/excel/src/flows/allocateThemesAutomatic.ts
@@ -7,7 +7,7 @@ export async function allocateThemesAutomaticFlow(
     context: Excel.RequestContext,
     range: string,
 ) {
-    const { inputs, positions, sheet, themes } = await themeGenerationFlow(
+    const { inputs, positions, sheet, themes, rangeInfo } = await themeGenerationFlow(
         context,
         range,
     );
@@ -20,5 +20,11 @@ export async function allocateThemesAutomaticFlow(
         },
     });
 
-    await writeAllocationsToSheet(positions, sheet, allocations, context);
+    await writeAllocationsToSheet(
+        positions,
+        sheet,
+        allocations,
+        context,
+        rangeInfo,
+    );
 }

--- a/packages/excel/src/flows/allocateThemesFromSheet.ts
+++ b/packages/excel/src/flows/allocateThemesFromSheet.ts
@@ -14,7 +14,7 @@ export async function allocateThemesFromSheetFlow(
 ) {
     console.log('Allocating themes from sheet', themeSheetName);
 
-    const { sheet, inputs, positions } = await getSheetInputsAndPositions(
+    const { sheet, inputs, positions, rangeInfo } = await getSheetInputsAndPositions(
         context,
         range,
     );
@@ -29,7 +29,13 @@ export async function allocateThemesFromSheetFlow(
         },
     });
 
-    await writeAllocationsToSheet(positions, sheet, allocations, context);
+    await writeAllocationsToSheet(
+        positions,
+        sheet,
+        allocations,
+        context,
+        rangeInfo,
+    );
 }
 
 export async function writeAllocationsToSheet(
@@ -37,13 +43,31 @@ export async function writeAllocationsToSheet(
     sheet: Excel.Worksheet,
     allocations: { theme: ShortTheme; score: number; belowThreshold: boolean }[],
     context: Excel.RequestContext,
+    rangeInfo: { rowIndex: number; columnIndex: number; rowCount: number; columnCount: number },
 ) {
+    const originalRange = sheet.getRangeByIndexes(
+        rangeInfo.rowIndex,
+        rangeInfo.columnIndex,
+        rangeInfo.rowCount,
+        rangeInfo.columnCount,
+    );
+    originalRange.load('values');
+    await context.sync();
+
+    const outputSheet = context.workbook.worksheets.add(`Allocation_${Date.now()}`);
+    outputSheet.getRange('A1:B1').values = [['Text', 'Theme']];
+    const target = outputSheet
+        .getRange('A2')
+        .getResizedRange(rangeInfo.rowCount - 1, 0);
+    target.values = originalRange.values;
+
     const batchSize = 1000;
     for (let i = 0; i < positions.length; i += batchSize) {
         const batch = positions.slice(i, i + batchSize);
         batch.forEach((pos, j) => {
             const alloc = allocations[i + j];
-            const cell = sheet.getCell(pos.row - 1, pos.col);
+            const rowIndex = pos.row - rangeInfo.rowIndex;
+            const cell = outputSheet.getCell(rowIndex, 1);
             cell.values = [[alloc.theme.label]];
             if (alloc.belowThreshold) {
                 cell.format.fill.color = '#FFF2CC';

--- a/packages/excel/src/flows/themeGenerationFlow.ts
+++ b/packages/excel/src/flows/themeGenerationFlow.ts
@@ -7,7 +7,7 @@ export async function themeGenerationFlow(
     context: Excel.RequestContext,
     range: string,
 ) {
-    const { sheet, inputs, positions } = await getSheetInputsAndPositions(
+    const { sheet, inputs, positions, rangeInfo } = await getSheetInputsAndPositions(
         context,
         range,
     );
@@ -74,6 +74,6 @@ export async function themeGenerationFlow(
         result.themes,
     );
 
-    return { inputs, positions, sheet, themes: result.themes }; // Return the inputs and positions for further processing
+    return { inputs, positions, sheet, themes: result.themes, rangeInfo }; // Return the inputs and positions for further processing
     // by other flows
 }

--- a/packages/excel/src/services/__tests__/flows-preserve-rows.test.ts
+++ b/packages/excel/src/services/__tests__/flows-preserve-rows.test.ts
@@ -17,27 +17,39 @@ jest.mock('wink-eng-lite-web-model', () => ({}));
 describe('flows writing', () => {
     it('preserves empty rows when writing results', async () => {
         const cellMocks: any[] = [];
-        const sheet = {
+        const outputSheet = {
             getCell: jest.fn((r: number, c: number) => {
                 const cell = { values: undefined };
                 cellMocks.push({ r, c, cell });
                 return cell;
             }),
+            getRange: jest.fn(() => ({
+                values: undefined,
+                getResizedRange: jest.fn(() => ({ values: undefined })),
+            })),
+            getRangeByIndexes: jest.fn(() => ({ values: undefined })),
+        } as any;
+        const context = {
+            workbook: { worksheets: { add: jest.fn(() => outputSheet) } },
+            sync: jest.fn().mockResolvedValue(undefined),
         } as any;
         (getSheetInputsAndPositions as jest.Mock).mockResolvedValue({
             inputs: ['one two', 'three'],
             positions: [
-                { row: 1, col: 1 }, // row 1
-                { row: 3, col: 1 }, // row 3 (row 2 empty)
+                { row: 1, col: 1 },
+                { row: 3, col: 1 },
             ],
-            sheet,
+            sheet: {
+                getRangeByIndexes: jest.fn(() => ({ load: jest.fn(), values: [['one two'], ['',], ['three']] })),
+            },
+            rangeInfo: { rowIndex: 0, columnIndex: 0, rowCount: 3, columnCount: 1 },
         });
 
-        const context = { sync: jest.fn().mockResolvedValue(undefined) } as any;
         await countWordsFlow(context, 'A:A');
 
-        expect(cellMocks[0].r).toBe(0);
-        expect(cellMocks[1].r).toBe(2);
+        expect(context.workbook.worksheets.add).toHaveBeenCalled();
+        expect(cellMocks[0].r).toBe(1);
+        expect(cellMocks[1].r).toBe(3);
         expect(cellMocks[0].cell.values).toEqual([[2]]);
         expect(cellMocks[1].cell.values).toEqual([[1]]);
     });

--- a/packages/excel/src/services/getSheetInputsAndPositions.ts
+++ b/packages/excel/src/services/getSheetInputsAndPositions.ts
@@ -78,5 +78,11 @@ export async function getSheetInputsAndPositions(
         sheet,
         inputs,
         positions,
+        rangeInfo: {
+            rowIndex,
+            columnIndex,
+            rowCount,
+            columnCount,
+        },
     };
 }


### PR DESCRIPTION
## Summary
- extend `getSheetInputsAndPositions` to return range info
- add new sheet output logic for sentiment analysis
- update theme allocation flows to write to a new sheet
- update text utility flows (tokens, sentences, word count) to write to new sheet
- propagate range info through theme generation
- adjust tests for new sheet behaviour

## Testing
- `bun run lint` *(fails: sessionStorage not defined)*
- `bun run test`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_b_6878ac1331408329a051ddfba825aa3c