### PR TITLE
Switch Start button icon based on label

### DIFF
--- a/packages/excel/manifest.xml
+++ b/packages/excel/manifest.xml
@@ -320,11 +320,11 @@
                                     </Supertip>
                                     <Icon>
                                         <bt:Image size="16"
-                                                  resid="SettingsIcon.16x16" />
+                                                  resid="Icon.16x16" />
                                         <bt:Image size="32"
-                                                  resid="SettingsIcon.32x32" />
+                                                  resid="Icon.32x32" />
                                         <bt:Image size="80"
-                                                  resid="SettingsIcon.80x80" />
+                                                  resid="Icon.80x80" />
                                     </Icon>
                                     <Action xsi:type="ExecuteFunction">
                                         <FunctionName>openSettingsHandler</FunctionName>

--- a/packages/excel/src/services/ribbon.ts
+++ b/packages/excel/src/services/ribbon.ts
@@ -102,3 +102,30 @@ export function updateHomeStartButtonLabel(label: string) {
         ],
     });
 }
+
+export function updateHomeStartButtonIcon(useSettingsIcon: boolean) {
+    const base = window.location.origin;
+    const prefix = useSettingsIcon ? 'icons/cog' : 'icon';
+    Office.ribbon.requestUpdate({
+        tabs: [
+            {
+                id: 'TabPulse',
+                groups: [
+                    {
+                        id: 'PulseGroup',
+                        controls: [
+                            {
+                                id: 'HomePulseStartButton',
+                                icon: [
+                                    { size: 16, sourceLocation: `${base}/assets/${prefix}-16.png` },
+                                    { size: 32, sourceLocation: `${base}/assets/${prefix}-32.png` },
+                                    { size: 80, sourceLocation: `${base}/assets/${prefix}-80.png` },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    });
+}

--- a/packages/excel/src/taskpane/Taskpane.tsx
+++ b/packages/excel/src/taskpane/Taskpane.tsx
@@ -24,10 +24,12 @@ function checkForLogin(success?: () => void, failure?: () => void) {
     if (token && email && orgId) {
         Ribbon.enableRibbonButtons();
         Ribbon.updateHomeStartButtonLabel('Settings');
+        Ribbon.updateHomeStartButtonIcon(true);
         success?.();
     } else {
         Ribbon.disableRibbonButtons();
         Ribbon.updateHomeStartButtonLabel('Start');
+        Ribbon.updateHomeStartButtonIcon(false);
         failure?.();
     }
 }


### PR DESCRIPTION
## Summary
- show the Pulse logo on the Home `Start` button by default
- add a ribbon helper to swap the start button's icon
- toggle between logo and cog icons based on login state

## Testing
- `bun run lint` *(fails: `sessionStorage` not defined)*
- `bun run test`
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_b_6878b565db748329a4ffe01169c4a519