### PR TITLE
Handle fast sentiment workflow

### DIFF
--- a/packages/sheets/src/analyzeSentiment.ts
+++ b/packages/sheets/src/analyzeSentiment.ts
@@ -47,8 +47,9 @@ export async function analyzeSentimentFlow(dataRange: string) {
         return;
     }
 
+    const useFast = inputs.length < 200;
     const data = await analyzeSentiment(inputs, {
-        fast: false,
+        fast: useFast,
         onProgress: (message) => {
             ss.toast(message, 'Pulse');
         },


### PR DESCRIPTION
## Summary
- update API client to track jobs for synchronous requests
- remove forced `fast` setting from API calls
- mark jobs failed on bad responses
- run sentiment analysis in `fast` mode when there are fewer than 200 inputs

## Testing
- `bun run lint` *(fails: No files matching pattern)*
- `bun run test`
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_b_6878bac8de3c832986b0ab9673724366