### PR TITLE
Add quick sheet activation and links in feed

### DIFF
--- a/packages/common/src/jobs.ts
+++ b/packages/common/src/jobs.ts
@@ -5,6 +5,7 @@ export interface FeedItem {
     title: string;
     status: 'completed' | 'failed' | 'in-progress' | 'waiting';
     message?: string;
+    sheetName?: string;
 }
 
 const feedItems = new Map<string, FeedItem>();
@@ -18,11 +19,13 @@ export function createItem({
     title,
     message,
     status = 'waiting',
+    sheetName,
 }: {
     jobId?: string;
     title: string;
     message?: string;
     status?: 'waiting' | 'in-progress';
+    sheetName?: string;
 }): FeedItem {
     if (!jobId) {
         jobId = crypto.randomUUID();
@@ -35,6 +38,7 @@ export function createItem({
         title,
         status,
         message,
+        sheetName,
     };
     feedItems.set(jobId, item);
     return item;
@@ -45,11 +49,13 @@ export function updateItem({
     status,
     message,
     title,
+    sheetName,
 }: {
     jobId: string;
     status?: Exclude<FeedItem['status'], 'waiting' | 'in-progress'>;
     message?: string;
     title?: string;
+    sheetName?: string;
 }) {
     const item = feedItems.get(jobId);
     if (!item) {
@@ -66,6 +72,9 @@ export function updateItem({
     if (title) {
         item.title = title;
     }
+    if (sheetName) {
+        item.sheetName = sheetName;
+    }
     item.updatedAt = Date.now();
 
     feedItems.set(jobId, item);
@@ -76,4 +85,8 @@ export function getFeed(): FeedItem[] {
     return Array.from(feedItems.values()).sort(
         (a, b) => a.createdAt - b.createdAt,
     );
+}
+
+export function getItem(jobId: string): FeedItem | undefined {
+    return feedItems.get(jobId);
 }

--- a/packages/excel/src/flows/allocateThemesAutomatic.ts
+++ b/packages/excel/src/flows/allocateThemesAutomatic.ts
@@ -7,6 +7,7 @@ export async function allocateThemesAutomaticFlow(
     context: Excel.RequestContext,
     range: string,
 ) {
+    const startTime = Date.now();
     const { inputs, positions, sheet, themes, rangeInfo } = await themeGenerationFlow(
         context,
         range,
@@ -26,5 +27,6 @@ export async function allocateThemesAutomaticFlow(
         allocations,
         context,
         rangeInfo,
+        startTime,
     );
 }

--- a/packages/excel/src/flows/allocateThemesFromSet.ts
+++ b/packages/excel/src/flows/allocateThemesFromSet.ts
@@ -4,6 +4,8 @@ import {
     ShortTheme,
 } from 'pulse-common/themes';
 import { getSheetInputsAndPositions } from '../services/getSheetInputsAndPositions';
+import { maybeActivateSheet } from '../services/maybeActivateSheet';
+import { getFeed, updateItem } from 'pulse-common/jobs';
 import { Pos } from 'pulse-common';
 import { ALLOCATION_THRESHOLD } from './constants';
 
@@ -13,6 +15,7 @@ export async function allocateThemesFromSetFlow(
     themeSetName: string,
 ) {
     console.log('Allocating themes from set', themeSetName);
+    const startTime = Date.now();
 
     const { sheet, inputs, positions, rangeInfo } = await getSheetInputsAndPositions(
         context,
@@ -40,6 +43,7 @@ export async function allocateThemesFromSetFlow(
         allocations,
         context,
         rangeInfo,
+        startTime,
     );
 }
 
@@ -49,6 +53,7 @@ export async function writeAllocationsToSheet(
     allocations: { theme: ShortTheme; score: number; belowThreshold: boolean }[],
     context: Excel.RequestContext,
     rangeInfo: { rowIndex: number; columnIndex: number; rowCount: number; columnCount: number },
+    startTime: number,
 ) {
     const originalRange = sheet.getRangeByIndexes(
         rangeInfo.rowIndex,
@@ -79,5 +84,13 @@ export async function writeAllocationsToSheet(
             }
         });
         await context.sync();
+    }
+
+    await maybeActivateSheet(context, outputSheet, startTime);
+
+    const feed = getFeed();
+    const last = feed[feed.length - 1];
+    if (last) {
+        updateItem({ jobId: last.jobId, sheetName: outputSheet.name });
     }
 }

--- a/packages/excel/src/flows/countWords.ts
+++ b/packages/excel/src/flows/countWords.ts
@@ -1,4 +1,5 @@
 import { getSheetInputsAndPositions } from '../services/getSheetInputsAndPositions';
+import { maybeActivateSheet } from '../services/maybeActivateSheet';
 import winkNLP from 'wink-nlp';
 import model from 'wink-eng-lite-web-model';
 
@@ -10,6 +11,7 @@ export async function countWordsFlow(
     range: string,
 ): Promise<void> {
     console.log('countWordsFlow', range);
+    const startTime = Date.now();
     const { inputs, positions, sheet, rangeInfo } = await getSheetInputsAndPositions(
         context,
         range,
@@ -65,4 +67,6 @@ export async function countWordsFlow(
         });
         await context.sync();
     }
+
+    await maybeActivateSheet(context, outputSheet, startTime);
 }

--- a/packages/excel/src/flows/matrixThemesAutomatic.ts
+++ b/packages/excel/src/flows/matrixThemesAutomatic.ts
@@ -7,6 +7,7 @@ export async function matrixThemesAutomaticFlow(
     context: Excel.RequestContext,
     range: string,
 ) {
+    const startTime = Date.now();
     const { inputs, positions, themes } = await themeGenerationFlow(context, range);
     const expanded = expandInputsWithBlankRows(inputs, positions);
 
@@ -22,5 +23,6 @@ export async function matrixThemesAutomaticFlow(
         matrix,
         inputs: expanded,
         themes,
+        startTime,
     });
 }

--- a/packages/excel/src/flows/matrixThemesFromSet.ts
+++ b/packages/excel/src/flows/matrixThemesFromSet.ts
@@ -9,6 +9,7 @@ export async function matrixThemesFromSetFlow(
     themeSetName: string,
 ) {
     console.log('Allocating themes matrix from set', themeSetName);
+    const startTime = Date.now();
 
     const { inputs, positions } = await getSheetInputsAndPositions(context, range);
     const expanded = expandInputsWithBlankRows(inputs, positions);
@@ -33,5 +34,6 @@ export async function matrixThemesFromSetFlow(
         matrix,
         inputs: expanded,
         themes: themeSet.themes,
+        startTime,
     });
 }

--- a/packages/excel/src/flows/matrixThemesFromSheet.ts
+++ b/packages/excel/src/flows/matrixThemesFromSheet.ts
@@ -10,6 +10,7 @@ export async function matrixThemesFromSheetFlow(
     themeSheetName: string,
 ) {
     console.log('Allocating themes matrix from sbeet', themeSheetName);
+    const startTime = Date.now();
 
     const { inputs, positions } = await getSheetInputsAndPositions(context, range);
     const expanded = expandInputsWithBlankRows(inputs, positions);
@@ -29,5 +30,6 @@ export async function matrixThemesFromSheetFlow(
         matrix,
         inputs: expanded,
         themes: themes,
+        startTime,
     });
 }

--- a/packages/excel/src/flows/similarityMatrixThemesAutomatic.ts
+++ b/packages/excel/src/flows/similarityMatrixThemesAutomatic.ts
@@ -8,6 +8,7 @@ export async function similarityMatrixThemesAutomaticFlow(
     range: string,
 ) {
     console.log('Allocating themes similarity matrix automatically');
+    const startTime = Date.now();
 
     const { inputs, positions, themes } = await themeGenerationFlow(context, range);
     const expanded = expandInputsWithBlankRows(inputs, positions);
@@ -25,5 +26,6 @@ export async function similarityMatrixThemesAutomaticFlow(
         matrix,
         inputs: expanded,
         themes,
+        startTime,
     });
 }

--- a/packages/excel/src/flows/similarityMatrixThemesFromSet.ts
+++ b/packages/excel/src/flows/similarityMatrixThemesFromSet.ts
@@ -9,6 +9,7 @@ export async function similarityMatrixThemesFromSetFlow(
     themeSetName: string,
 ) {
     console.log('Allocating themes similarity matrix from set', themeSetName);
+    const startTime = Date.now();
 
     const { inputs, positions } = await getSheetInputsAndPositions(context, range);
     const expanded = expandInputsWithBlankRows(inputs, positions);
@@ -33,5 +34,6 @@ export async function similarityMatrixThemesFromSetFlow(
         matrix,
         inputs: expanded,
         themes: themeSet.themes,
+        startTime,
     });
 }

--- a/packages/excel/src/flows/similarityMatrixThemesFromSheet.ts
+++ b/packages/excel/src/flows/similarityMatrixThemesFromSheet.ts
@@ -13,6 +13,7 @@ export async function similarityMatrixThemesFromSheetFlow(
         'Allocating themes similarity matrix from sheet',
         themeSheetName,
     );
+    const startTime = Date.now();
 
     const { inputs, positions } = await getSheetInputsAndPositions(context, range);
     const expanded = expandInputsWithBlankRows(inputs, positions);
@@ -32,5 +33,6 @@ export async function similarityMatrixThemesFromSheetFlow(
         matrix,
         inputs: expanded,
         themes,
+        startTime,
     });
 }

--- a/packages/excel/src/flows/splitIntoSentences.ts
+++ b/packages/excel/src/flows/splitIntoSentences.ts
@@ -1,10 +1,12 @@
 import { getSheetInputsAndPositions } from '../services/getSheetInputsAndPositions';
+import { maybeActivateSheet } from '../services/maybeActivateSheet';
 
 export async function splitIntoSentencesFlow(
     context: Excel.RequestContext,
     range: string,
 ): Promise<void> {
     console.log('splitIntoSentencesFlow', range);
+    const startTime = Date.now();
     const { inputs, positions, sheet, rangeInfo } = await getSheetInputsAndPositions(
         context,
         range,
@@ -77,4 +79,6 @@ export async function splitIntoSentencesFlow(
         });
         await context.sync();
     }
+
+    await maybeActivateSheet(context, outputSheet, startTime);
 }

--- a/packages/excel/src/flows/splitIntoTokens.ts
+++ b/packages/excel/src/flows/splitIntoTokens.ts
@@ -1,4 +1,5 @@
 import { getSheetInputsAndPositions } from '../services/getSheetInputsAndPositions';
+import { maybeActivateSheet } from '../services/maybeActivateSheet';
 import winkNLP from 'wink-nlp';
 import model from 'wink-eng-lite-web-model';
 
@@ -10,6 +11,7 @@ export async function splitIntoTokensFlow(
     range: string,
 ): Promise<void> {
     console.log('splitIntoTokensFlow', range);
+    const startTime = Date.now();
     const { inputs, positions, sheet, rangeInfo } = await getSheetInputsAndPositions(
         context,
         range,
@@ -73,4 +75,6 @@ export async function splitIntoTokensFlow(
         });
         await context.sync();
     }
+
+    await maybeActivateSheet(context, outputSheet, startTime);
 }

--- a/packages/excel/src/services/maybeActivateSheet.ts
+++ b/packages/excel/src/services/maybeActivateSheet.ts
@@ -1,0 +1,11 @@
+export async function maybeActivateSheet(
+    context: Excel.RequestContext,
+    sheet: Excel.Worksheet,
+    startTime: number,
+    thresholdMs = 20000,
+): Promise<void> {
+    if (Date.now() - startTime <= thresholdMs) {
+        sheet.activate();
+        await context.sync();
+    }
+}

--- a/packages/excel/src/shared-runtime/shared-runtime.tsx
+++ b/packages/excel/src/shared-runtime/shared-runtime.tsx
@@ -48,7 +48,7 @@ async function generateThemesHandler(event: any) {
             }
 
             openFeedHandler();
-            await themeGenerationFlow(context, confirmed);
+            await themeGenerationFlow(context, confirmed, Date.now());
         } catch (e) {
             console.error('Dialog error', e);
         } finally {

--- a/packages/excel/src/taskpane/Feed.tsx
+++ b/packages/excel/src/taskpane/Feed.tsx
@@ -39,6 +39,14 @@ export function Feed({ api }: Props) {
         return () => clearInterval(interval);
     }, []);
 
+    const goToSheet = async (name: string) => {
+        await Excel.run(async (context) => {
+            const sheet = context.workbook.worksheets.getItem(name);
+            sheet.activate();
+            await context.sync();
+        });
+    };
+
     const getStatusColor = (status: FeedItem['status']) => {
         switch (status) {
             case 'completed':
@@ -62,12 +70,24 @@ export function Feed({ api }: Props) {
                     {feed.map((item) => (
                         <div
                             key={item.jobId}
-                            className={`p-4 border-l-4 ${getStatusColor(item.status)} bg-white shadow-sm`}
+                            onClick={() => item.sheetName && goToSheet(item.sheetName)}
+                            className={`p-4 border-l-4 ${getStatusColor(item.status)} bg-white shadow-sm cursor-pointer`}
                         >
-                            <h3 className="font-bold">{item.title}</h3>
-                            <p className="text-sm text-gray-600">
-                                {item.message}
-                            </p>
+                            <div className="flex justify-between items-center">
+                                <h3 className="font-bold">{item.title}</h3>
+                                {item.sheetName && (
+                                    <button
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            goToSheet(item.sheetName!);
+                                        }}
+                                        className="text-blue-600 underline"
+                                    >
+                                        Open
+                                    </button>
+                                )}
+                            </div>
+                            <p className="text-sm text-gray-600">{item.message}</p>
                         </div>
                     ))}
                 </div>


### PR DESCRIPTION
## Summary
- activate new sheets only when jobs finish quickly
- link completed jobs to their output sheets
- allow navigating to sheets from feed

## Testing
- `bun run lint` *(fails: no files matching pattern, 380 errors)*
- `bun run test` *(fails: 1 failed test suite)*
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_b_6878c96202448329b4a041bfd099fcea