### PR TITLE
Integrate pulse-common auth for Sheets add-on

### DIFF
--- a/packages/sheets/__tests__/auth.test.ts
+++ b/packages/sheets/__tests__/auth.test.ts
@@ -1,0 +1,84 @@
+import { configureFetch } from 'pulse-common/api';
+
+// Mock OAuth2 service
+const service = {
+  hasAccess: () => true,
+  getAccessToken: () => 'tok',
+  getAuthorizationUrl: () => 'https://auth',
+  reset: () => {
+    resetCalled = true;
+  },
+  handleCallback: (_req: any) => true,
+  setAuthorizationBaseUrl: () => service,
+  setCache: () => service,
+  setLock: () => service,
+  setTokenUrl: () => service,
+  setClientId: () => service,
+  setClientSecret: () => service,
+  setCallbackFunction: () => service,
+  setPropertyStore: () => service,
+  setScope: () => service,
+  setParam: () => service,
+};
+let resetCalled = false;
+
+// Mock global services
+(global as any).OAuth2 = { createService: () => service };
+const userProps: Record<string, string> = {};
+(global as any).PropertiesService = {
+  getUserProperties: () => ({
+    getProperty: (k: string) => userProps[k] || null,
+    setProperty: (k: string, v: string) => {
+      userProps[k] = v;
+    },
+    deleteProperty: (k: string) => {
+      delete userProps[k];
+    },
+  }),
+  getScriptProperties: () => ({
+    getProperty: () => '',
+  }),
+};
+(global as any).CacheService = { getUserCache: () => ({}) };
+(global as any).LockService = { getUserLock: () => ({}) };
+(global as any).HtmlService = { createHtmlOutput: (s: string) => ({ getContent: () => s }) };
+
+const fetchCalls: any[] = [];
+configureFetch(async (url, options) => {
+  fetchCalls.push({ url, options });
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ organizationId: 'org-1' }),
+    text: async () => '',
+  };
+});
+
+let findOrganization: typeof import('../src/auth').findOrganization;
+let isAuthorized: typeof import('../src/auth').isAuthorized;
+let getAuthorizationUrl: typeof import('../src/auth').getAuthorizationUrl;
+let disconnect: typeof import('../src/auth').disconnect;
+
+beforeAll(async () => {
+  const mod = await import('../src/auth');
+  findOrganization = mod.findOrganization;
+  isAuthorized = mod.isAuthorized;
+  getAuthorizationUrl = mod.getAuthorizationUrl;
+  disconnect = mod.disconnect;
+});
+
+test('findOrganization stores org info', async () => {
+  const res = await findOrganization('user@test.com');
+  expect(res.success).toBe(true);
+  expect(userProps['USER_EMAIL']).toBe('user@test.com');
+  expect(userProps['ORG_ID']).toBe('org-1');
+  expect(fetchCalls.length).toBe(1);
+});
+
+test('authorization helpers delegate to service', () => {
+  expect(isAuthorized()).toBe(true);
+  expect(getAuthorizationUrl()).toBe('https://auth');
+  disconnect();
+  expect(resetCalled).toBe(true);
+});

--- a/packages/sheets/src/Code.ts
+++ b/packages/sheets/src/Code.ts
@@ -1,8 +1,9 @@
 /// <reference types="google-apps-script" />
 
 import { configureClient, configureFetch, configureSleep, configureStorage, FetchOptions, getThemeSets, saveThemeSet, renameThemeSet, deleteThemeSet } from "pulse-common";
-import { isAuthorized } from "./auth";
-import { WEB_BASE } from "./config";
+import { isAuthorized, getAccessToken } from "./auth";
+import { WEB_BASE, API_BASE } from "./config";
+import { configureAuth } from 'pulse-common/auth';
 import { getOAuthService } from "./getOAuthService";
 import { showAllocationModeDialog } from "./showAllocationModeDialog";
 import { showInputRangeDialog } from "./showInputRangeDialog";
@@ -25,11 +26,11 @@ const mapStatusToStatusText = {
     504: 'Gateway Timeout',
 };
 
-// OAuth2 for Apps Script integration (requires adding the OAuth2 library in appsscript.json)
+// Initialize Pulse API client using the shared auth utilities
 configureClient({
-    baseUrl: 'https://core.researchwiseai.com',
-    getAccessToken: async () => getOAuthService().getAccessToken(),
-})
+    baseUrl: API_BASE,
+    getAccessToken,
+});
 
 configureSleep(async (ms) => Utilities.sleep(ms))
 
@@ -92,7 +93,7 @@ export function onOpen() {
     const ui = SpreadsheetApp.getUi();
     const pulseMenu = ui.createMenu('Pulse');
     // If user is authorized, expose analysis and themes
-    if (getOAuthService().hasAccess()) {
+    if (isAuthorized()) {
         // Prompt for range before running sentiment analysis
         pulseMenu.addItem('Analyze Sentiment', 'clickAnalyzeSentiment');
         const themesMenu = ui

--- a/packages/sheets/src/Settings.html
+++ b/packages/sheets/src/Settings.html
@@ -9,30 +9,41 @@
   </head>
   <body>
     <div class="container">
-      <h5>Settings</h5>
-      <!-- Disconnected state: show email input and Connect button -->
-      <div id="disconnectedSection">
+      <h5>Pulse Settings</h5>
+      <!-- Login state -->
+      <div id="loginSection">
         <div class="input-field">
           <input id="email" type="email" />
-          <label for="email">Email Address</label>
+          <label for="email">Email address</label>
         </div>
         <button
           id="connectButton"
           class="btn waves-effect waves-light"
           onclick="lookupOrganization()"
         >
-          Connect
+          Start
+        </button>
+        <button
+          id="registerButton"
+          class="btn-flat"
+          onclick="register()"
+        >
+          Register
         </button>
       </div>
-      <!-- Connected state: show status and Disconnect button -->
+
+      <!-- Connected state -->
       <div id="connectedSection" style="display: none">
-        <p><span class="green-text text-darken-2">Connected</span></p>
+        <p>
+          <span class="green-text text-darken-2">Connected</span>
+          <span id="userEmail" class="ml-2"></span>
+        </p>
         <button
           id="disconnectButton"
           class="btn waves-effect waves-light"
           onclick="disconnect()"
         >
-          Disconnect
+          Logout
         </button>
       </div>
     </div>
@@ -43,6 +54,9 @@
       function onFailure(err) {
         M.toast({ html: 'Error: ' + err.message });
       }
+      function register() {
+        window.open(webBase + '/register', '_blank');
+      }
       function onOrgFound(res) {
         if (res.success) {
           M.toast({ html: 'Account found. Authorizing...' });
@@ -50,9 +64,9 @@
         } else if (res.notFound) {
           M.toast({
             html:
-              'No account found for that email address. To <a href="' +
+              'No account found for that email address. <a href="' +
               webBase +
-              '/register" target="_blank">register for ResearchWiseAI, click here</a>.',
+              '/register" target="_blank">Register here</a>.',
           });
         } else {
           M.toast({ html: 'Error finding organization' });
@@ -106,7 +120,7 @@
                   if (settings.isAuthorized) {
                     clearInterval(poll);
                     if (authWin && !authWin.closed) authWin.close();
-                    renderSettings(settings);
+                    render(settings);
                     google.script.run.updateMenu();
                   }
                 })
@@ -119,20 +133,20 @@
       // Fetch current settings (email & auth status), then render UI
       function loadSettings() {
         google.script.run
-          .withSuccessHandler(renderSettings)
+          .withSuccessHandler(render)
           .withFailureHandler(onFailure)
           .getSettings();
       }
       // Render UI based on authorization status
-      function renderSettings(res) {
+      function render(res) {
         const connected = res.isAuthorized;
         document.getElementById('connectedSection').style.display = connected
           ? ''
           : 'none';
-        document.getElementById('disconnectedSection').style.display = connected
-          ? 'none'
-          : '';
-        if (!connected) {
+        document.getElementById('loginSection').style.display = connected ? 'none' : '';
+        if (connected) {
+          document.getElementById('userEmail').innerText = res.email;
+        } else {
           document.getElementById('email').value = res.email || '';
           M.updateTextFields();
         }

--- a/packages/sheets/src/updateMenu.ts
+++ b/packages/sheets/src/updateMenu.ts
@@ -1,4 +1,4 @@
-import { getOAuthService } from './getOAuthService';
+import { isAuthorized } from './auth';
 
 /**
  * Updates the Pulse menu based on the current authorization state.
@@ -6,7 +6,7 @@ import { getOAuthService } from './getOAuthService';
 export function updateMenu() {
     const ui = SpreadsheetApp.getUi();
     const pulseMenu = ui.createMenu('Pulse');
-    if (getOAuthService().hasAccess()) {
+    if (isAuthorized()) {
         pulseMenu.addItem('Analyze Sentiment', 'analyzeSentiment');
         const themesMenu = ui
             .createMenu('Themes')


### PR DESCRIPTION
## Summary
- overhaul Sheets Settings sidebar UI
- implement Apps Script auth provider using pulse-common
- wire Code.ts to shared auth utilities
- update menu handling with isAuthorized
- add unit tests for Sheets auth logic

## Testing
- `bun run test`
- `bun run build`
- `bun run lint` *(fails: No files matching pattern and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68825f365c0883298301e6230f1c344d