### PR TITLE
Improve sheets workflows

### DIFF
--- a/packages/sheets/__tests__/workflows.test.ts
+++ b/packages/sheets/__tests__/workflows.test.ts
@@ -1,0 +1,103 @@
+import type { Theme } from 'pulse-common';
+import { analyzeSentiment, allocateThemes } from 'pulse-common/apiClient';
+import { getThemeSets } from 'pulse-common/themes';
+
+jest.mock('pulse-common/apiClient', () => ({
+    analyzeSentiment: jest.fn(),
+    allocateThemes: jest.fn(),
+}));
+
+jest.mock('pulse-common/themes', () => ({
+    getThemeSets: jest.fn(),
+}));
+
+let analyzeSentimentFlow: typeof import('../src/analyzeSentiment').analyzeSentimentFlow;
+let allocateThemesFromSet: typeof import('../src/allocateThemesFromSet').allocateThemesFromSet;
+
+const setValuesMock = jest.fn();
+const rangeMock = {
+    getValues: jest.fn(),
+    getRow: jest.fn(() => 1),
+    getColumn: jest.fn(() => 1),
+    getSheet: jest.fn(),
+};
+const sheetMock = {
+    getRange: jest.fn((a: any, b?: any, c?: any, d?: any) => {
+        if (typeof a === 'string') {
+            return rangeMock;
+        }
+        return { setValues: setValuesMock };
+    }),
+};
+rangeMock.getSheet.mockReturnValue(sheetMock);
+const ssMock = {
+    getSheetByName: jest.fn(() => sheetMock),
+    toast: jest.fn(),
+};
+(global as any).SpreadsheetApp = {
+    getActiveSpreadsheet: () => ssMock,
+    getUi: () => ({ alert: jest.fn() }),
+};
+
+beforeAll(async () => {
+    const mod1 = await import('../src/analyzeSentiment');
+    analyzeSentimentFlow = mod1.analyzeSentimentFlow;
+    const mod2 = await import('../src/allocateThemesFromSet');
+    allocateThemesFromSet = mod2.allocateThemesFromSet;
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+test('analyzeSentimentFlow maps results to rows', async () => {
+    rangeMock.getValues.mockReturnValue([
+        ['Header'],
+        ['good'],
+        [''],
+        ['bad'],
+    ]);
+    (analyzeSentiment as jest.Mock).mockResolvedValue({
+        results: [{ sentiment: 'pos' }, { sentiment: 'neg' }],
+    });
+
+    await analyzeSentimentFlow('Sheet1!A1:A4', true);
+
+    expect(analyzeSentiment).toHaveBeenCalledWith(['good', 'bad'], expect.any(Object));
+    expect(setValuesMock).toHaveBeenCalledWith([
+        ['pos'],
+        [''],
+        ['neg'],
+    ]);
+});
+
+test('allocateThemesFromSet maps allocations to rows', async () => {
+    rangeMock.getValues.mockReturnValue([
+        ['Header'],
+        ['foo'],
+        [''],
+        ['bar'],
+    ]);
+    (getThemeSets as jest.Mock).mockResolvedValue([
+        {
+            name: 'Test',
+            themes: [
+                { label: 'A', representatives: [] },
+                { label: 'B', representatives: [] },
+            ] as Theme[],
+        },
+    ]);
+    (allocateThemes as jest.Mock).mockResolvedValue([
+        { theme: { label: 'A', representatives: [] }, score: 1, belowThreshold: false },
+        { theme: { label: 'B', representatives: [] }, score: 1, belowThreshold: false },
+    ]);
+
+    await allocateThemesFromSet('Sheet1!A1:A4', 'Test', true);
+
+    expect(allocateThemes).toHaveBeenCalledWith(['foo', 'bar'], expect.any(Object));
+    expect(setValuesMock).toHaveBeenCalledWith([
+        ['A'],
+        [''],
+        ['B'],
+    ]);
+});

--- a/packages/sheets/src/AllocationModeDialog.html
+++ b/packages/sheets/src/AllocationModeDialog.html
@@ -17,6 +17,12 @@
     </head>
     <body class="container">
         <input id="dataRange" type="hidden" value="<?= dataRange ?>" />
+        <p>
+            <label>
+                <input type="checkbox" id="hasHeader" <?= hasHeader ? 'checked' : '' ?> />
+                <span>First row is header</span>
+            </label>
+        </p>
         <form id="modeForm">
             <p>
                 <label>
@@ -67,15 +73,16 @@
                 const form = document.getElementById('modeForm');
                 const mode = form.mode.value;
                 const dr = document.getElementById('dataRange').value;
+                const hasHeader = document.getElementById('hasHeader').checked;
                 // Start the allocation job and close the dialog immediately
                 if (mode === 'new') {
                     const name = prompt('Name for this Theme Set?');
                     if (!name) return;
                     google.script.run.showRangeDialog(dr, name);
                 } else if (mode === 'auto') {
-                    google.script.run.allocateThemesAutomatic(dr);
+                    google.script.run.allocateThemesAutomatic(dr, hasHeader);
                 } else {
-                    google.script.run.allocateThemesFromSet(dr, mode);
+                    google.script.run.allocateThemesFromSet(dr, mode, hasHeader);
                 }
                 google.script.host.close();
             }

--- a/packages/sheets/src/Code.ts
+++ b/packages/sheets/src/Code.ts
@@ -158,12 +158,16 @@ export function debounceByArgs<F extends (...args: any[]) => any>(
  * @param {string} dataRange A1 notation of the data range to allocate.
  * @param {string} mode Allocation mode: 'generation' or 'allocation'
  */
-export function themeGenerationRouting(dataRange: string, mode: 'generation' | 'allocation') {
+export function themeGenerationRouting(
+    dataRange: string,
+    mode: 'generation' | 'allocation',
+    hasHeader = false,
+) {
     console.log('submitSelectedInputRangeForGeneration', dataRange, mode);
     if (mode === 'generation') {
-        generateThemesFlow(dataRange);
+        generateThemesFlow(dataRange, hasHeader);
     } else {
-        allocateThemesWithRange(dataRange);
+        allocateThemesWithRange(dataRange, hasHeader);
     }
 }
 
@@ -172,8 +176,12 @@ const debouncedThemeGenerationRouting = debounceByArgs(
     20000
 );
 
-export function submitSelectedInputRangeForGeneration(dataRange: string, mode: 'generation' | 'allocation') {
-    return debouncedThemeGenerationRouting(dataRange, mode);
+export function submitSelectedInputRangeForGeneration(
+    dataRange: string,
+    mode: 'generation' | 'allocation',
+    hasHeader = false,
+) {
+    return debouncedThemeGenerationRouting(dataRange, mode, hasHeader);
 }
 
 /**
@@ -183,8 +191,11 @@ export function submitSelectedInputRangeForGeneration(dataRange: string, mode: '
  * 
  * @param {string} dataRange A1 notation of the data range to allocate.
  */
-export function allocateThemesWithRange(dataRange: string) {
-    showAllocationModeDialog(dataRange);
+export function allocateThemesWithRange(
+    dataRange: string,
+    hasHeader = false,
+) {
+    showAllocationModeDialog(dataRange, hasHeader);
 }
 /**
  * Save a manually created theme set.

--- a/packages/sheets/src/InputRangeDialog.html
+++ b/packages/sheets/src/InputRangeDialog.html
@@ -10,14 +10,20 @@
   <body class="container">
     <input id="mode" type="hidden" value="<?= mode ?>" />
     <div class="input-field">
-      <input
-        id="dataRange"
-        type="text"
-        onfocus="pickRange()"
-        value="<?= dataRange ?>"
-      />
-      <label for="dataRange">Input Range (A1 notation)</label>
+        <input
+            id="dataRange"
+            type="text"
+            onfocus="pickRange()"
+            value="<?= dataRange ?>"
+        />
+        <label for="dataRange">Input Range (A1 notation)</label>
     </div>
+    <p>
+        <label>
+            <input type="checkbox" id="hasHeader" />
+            <span>First row is header</span>
+        </label>
+    </p>
     <button class="btn waves-effect waves-light" onclick="submitRange()">
       OK
     </button>
@@ -41,18 +47,19 @@
       function submitRange() {
         const dataRange = document.getElementById('dataRange').value;
         const mode = document.getElementById('mode').value;
+        const hasHeader = document.getElementById('hasHeader').checked;
         if (mode === 'sentiment') {
           google.script.run
             .withFailureHandler(function (err) {
               M.toast({ html: 'Error: ' + err.message });
             })
-            .analyzeSentimentFlow(dataRange);
+            .analyzeSentimentFlow(dataRange, hasHeader);
         } else {
           google.script.run
             .withFailureHandler(function (err) {
               M.toast({ html: 'Error: ' + err.message });
             })
-            .submitSelectedInputRangeForGeneration(dataRange, mode);
+            .submitSelectedInputRangeForGeneration(dataRange, mode, hasHeader);
         }
         google.script.host.close();
       }

--- a/packages/sheets/src/generateThemes.ts
+++ b/packages/sheets/src/generateThemes.ts
@@ -1,12 +1,13 @@
-import {
-    extractInputsWithHeader,
-    sampleInputs,
-    generateThemes,
-    saveThemeSet,
-} from 'pulse-common';
+import { generateThemes } from 'pulse-common/api';
+import { extractInputsWithHeader } from 'pulse-common/dataUtils';
+import { sampleInputs } from 'pulse-common/input';
+import { saveThemeSet } from 'pulse-common/themes';
 import { writeThemes } from './writeThemes';
 
-export async function generateThemesFlow(dataRange: string) {
+export async function generateThemesFlow(
+    dataRange: string,
+    hasHeader = false,
+) {
     const ui = SpreadsheetApp.getUi();
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     ss.toast('Starting theme generation...', 'Pulse');
@@ -20,9 +21,10 @@ export async function generateThemesFlow(dataRange: string) {
     }
     const values = dataRangeObj.getValues();
 
-    const { inputs, positions } = extractInputsWithHeader(values, {
+    const { header, inputs, positions } = extractInputsWithHeader(values, {
         rowOffset: dataRangeObj.getRow(),
         colOffset: dataRangeObj.getColumn(),
+        hasHeader,
     });
 
     console.log('inputs', inputs);
@@ -52,6 +54,9 @@ export async function generateThemesFlow(dataRange: string) {
     console.log('usedInputs', usedInputs);
     const themesResponse = await generateThemes(usedInputs, {
         fast: false,
+        context: hasHeader && header
+            ? `The column header is: ${header}`
+            : undefined,
         onProgress: (message) => {
             ss.toast(message, 'Pulse');
         },
@@ -73,6 +78,7 @@ export async function generateThemesFlow(dataRange: string) {
         inputs,
         positions,
         dataRangeObj,
+        header,
     };
 }
 

--- a/packages/sheets/src/showAllocationModeDialog.ts
+++ b/packages/sheets/src/showAllocationModeDialog.ts
@@ -4,10 +4,14 @@ import { getThemeSets } from 'pulse-common';
  * Opens a dialog to choose automatic theme generation or custom theme ranges.
  * @param {string} dataRange A1 notation of the data range to allocate.
  */
-export async function showAllocationModeDialog(dataRange: string) {
+export async function showAllocationModeDialog(
+    dataRange: string,
+    hasHeader = false,
+) {
     const ui = SpreadsheetApp.getUi();
     const template = HtmlService.createTemplateFromFile('AllocationModeDialog');
     template.dataRange = dataRange;
+    template.hasHeader = hasHeader;
     // Pass existing saved theme set names to the dialog template
     const themeSet = await getThemeSets();
     template.themeSetNames = themeSet.map(function (s) {

--- a/packages/sheets/src/writeThemesToSheet.ts
+++ b/packages/sheets/src/writeThemesToSheet.ts
@@ -1,0 +1,28 @@
+import type { Theme } from 'pulse-common';
+import { themesToRows } from 'pulse-common/dataUtils';
+
+export function writeThemesToSheet(themes: Theme[]) {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    let sheet = ss.getSheetByName('Themes');
+    if (!sheet) {
+        sheet = ss.insertSheet('Themes');
+    } else {
+        sheet.clear();
+    }
+
+    const headers = [
+        'Label',
+        'Short Label',
+        'Description',
+        'Representative 1',
+        'Representative 2',
+    ];
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    const rows = themesToRows(themes);
+    const target = sheet.getRange(2, 1, rows.length, headers.length);
+    if (rows.length > 0) {
+        target.setValues(rows);
+    } else {
+        target.clear();
+    }
+}


### PR DESCRIPTION
## Summary
- add header parameter support to analyzeSentimentFlow and theme allocation flows
- pipe header choice through dialogs and Code.ts helpers
- add `writeThemesToSheet` utility for Google Sheets
- update allocate workflows to map results using `expandWithBlankRows`
- provide workflow unit tests

## Testing
- `bun run lint` *(fails: 368 errors)*
- `bun run test`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_b_6882651218e0832985c6b270ecd36703