### PR TITLE
Add advanced analysis flows for Sheets

### DIFF
--- a/packages/sheets/__tests__/advancedFlows.test.ts
+++ b/packages/sheets/__tests__/advancedFlows.test.ts
@@ -1,0 +1,142 @@
+import { multiCode, splitSimilarityMatrix, getThemeSets } from 'pulse-common/themes';
+import { generateThemesFlow } from '../src/generateThemes';
+
+jest.mock('pulse-common/themes', () => ({
+    multiCode: jest.fn(),
+    splitSimilarityMatrix: jest.fn(),
+    getThemeSets: jest.fn(),
+}));
+
+jest.mock('../src/generateThemes', () => ({
+    generateThemesFlow: jest.fn(),
+}));
+
+let splitIntoSentencesFlow: typeof import('../src/splitIntoSentences').splitIntoSentencesFlow;
+let splitIntoTokensFlow: typeof import('../src/splitIntoTokens').splitIntoTokensFlow;
+let countWordsFlow: typeof import('../src/countWords').countWordsFlow;
+let matrixThemesAutomatic: typeof import('../src/matrixThemesAutomatic').matrixThemesAutomatic;
+let matrixThemesFromSet: typeof import('../src/matrixThemesFromSet').matrixThemesFromSet;
+let similarityMatrixThemesAutomatic: typeof import('../src/similarityMatrixThemesAutomatic').similarityMatrixThemesAutomatic;
+let similarityMatrixThemesFromSet: typeof import('../src/similarityMatrixThemesFromSet').similarityMatrixThemesFromSet;
+
+const setValuesMock = jest.fn();
+const setValueMock = jest.fn();
+const rangeMock = {
+    getValues: jest.fn(),
+    getRow: jest.fn(() => 1),
+    getColumn: jest.fn(() => 1),
+    getNumColumns: jest.fn(() => 1),
+    getSheet: jest.fn(),
+};
+const sheetMock = {
+    getRange: jest.fn((a: any, b?: any, c?: any, d?: any) => {
+        if (typeof a === 'string') return rangeMock;
+        return { setValues: setValuesMock, setValue: setValueMock };
+    }),
+};
+rangeMock.getSheet.mockReturnValue(sheetMock);
+const newSheetMock = {
+    getRange: jest.fn(() => ({ setValues: setValuesMock, setValue: setValueMock })),
+};
+const ssMock = {
+    getSheetByName: jest.fn(() => sheetMock),
+    getRange: jest.fn(() => rangeMock),
+    insertSheet: jest.fn(() => newSheetMock),
+    toast: jest.fn(),
+};
+(global as any).SpreadsheetApp = {
+    getActiveSpreadsheet: () => ssMock,
+    getUi: () => ({ alert: jest.fn(), prompt: () => ({ getSelectedButton: () => ({}) }) }),
+};
+
+beforeAll(async () => {
+    const mod1 = await import('../src/splitIntoSentences');
+    splitIntoSentencesFlow = mod1.splitIntoSentencesFlow;
+    const mod2 = await import('../src/splitIntoTokens');
+    splitIntoTokensFlow = mod2.splitIntoTokensFlow;
+    const mod3 = await import('../src/countWords');
+    countWordsFlow = mod3.countWordsFlow;
+    const mod4 = await import('../src/matrixThemesAutomatic');
+    matrixThemesAutomatic = mod4.matrixThemesAutomatic;
+    const mod5 = await import('../src/matrixThemesFromSet');
+    matrixThemesFromSet = mod5.matrixThemesFromSet;
+    const mod6 = await import('../src/similarityMatrixThemesAutomatic');
+    similarityMatrixThemesAutomatic = mod6.similarityMatrixThemesAutomatic;
+    const mod7 = await import('../src/similarityMatrixThemesFromSet');
+    similarityMatrixThemesFromSet = mod7.similarityMatrixThemesFromSet;
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+test('splitIntoSentencesFlow creates new sheet', () => {
+    rangeMock.getValues.mockReturnValue([["a. b."], ["c"]]);
+    splitIntoSentencesFlow('Sheet1!A1:A2');
+    expect(ssMock.insertSheet).toHaveBeenCalled();
+    expect(setValuesMock).toHaveBeenCalledWith([["Text", "Sentence 1", "Sentence 2"]]);
+});
+
+test('splitIntoTokensFlow creates new sheet', () => {
+    rangeMock.getValues.mockReturnValue([["a b"], ["c"]]);
+    splitIntoTokensFlow('Sheet1!A1:A2');
+    expect(ssMock.insertSheet).toHaveBeenCalled();
+    expect(setValuesMock).toHaveBeenCalledWith([["Text", "Token 1", "Token 2"]]);
+});
+
+test('countWordsFlow writes counts', () => {
+    rangeMock.getValues.mockReturnValue([["a b"], ["c"]]);
+    countWordsFlow('Sheet1!A1:A2');
+    expect(ssMock.insertSheet).toHaveBeenCalled();
+    expect(setValuesMock).toHaveBeenCalledWith([["Text", "Word Count"]]);
+});
+
+test('matrixThemesAutomatic calls multiCode', async () => {
+    (generateThemesFlow as jest.Mock).mockResolvedValue({
+        inputs: ['x'],
+        positions: [{ row: 1, col: 1 }],
+        themes: [{ label: 'A', representatives: [] }],
+    });
+    (multiCode as jest.Mock).mockResolvedValue([[true]]);
+
+    await matrixThemesAutomatic('Sheet1!A1:A2');
+
+    expect(multiCode).toHaveBeenCalled();
+    expect(ssMock.insertSheet).toHaveBeenCalled();
+});
+
+test('matrixThemesFromSet loads theme set', async () => {
+    rangeMock.getValues.mockReturnValue([["x"]]);
+    (getThemeSets as jest.Mock).mockResolvedValue([{ name: 'Set1', themes: [{ label: 'A', representatives: [] }] }]);
+    (multiCode as jest.Mock).mockResolvedValue([[true]]);
+
+    await matrixThemesFromSet('Sheet1!A1:A1', 'Set1');
+
+    expect(getThemeSets).toHaveBeenCalled();
+    expect(multiCode).toHaveBeenCalled();
+});
+
+test('similarityMatrixThemesAutomatic calls splitSimilarityMatrix', async () => {
+    (generateThemesFlow as jest.Mock).mockResolvedValue({
+        inputs: ['x'],
+        positions: [{ row: 1, col: 1 }],
+        themes: [{ label: 'A', representatives: [] }],
+    });
+    (splitSimilarityMatrix as jest.Mock).mockResolvedValue([[0.5]]);
+
+    await similarityMatrixThemesAutomatic('Sheet1!A1:A2');
+
+    expect(splitSimilarityMatrix).toHaveBeenCalled();
+    expect(ssMock.insertSheet).toHaveBeenCalled();
+});
+
+test('similarityMatrixThemesFromSet uses theme set', async () => {
+    rangeMock.getValues.mockReturnValue([["x"]]);
+    (getThemeSets as jest.Mock).mockResolvedValue([{ name: 'Set1', themes: [{ label: 'A', representatives: [] }] }]);
+    (splitSimilarityMatrix as jest.Mock).mockResolvedValue([[0.2]]);
+
+    await similarityMatrixThemesFromSet('Sheet1!A1:A1', 'Set1');
+
+    expect(getThemeSets).toHaveBeenCalled();
+    expect(splitSimilarityMatrix).toHaveBeenCalled();
+});

--- a/packages/sheets/src/Code.ts
+++ b/packages/sheets/src/Code.ts
@@ -8,6 +8,13 @@ import { getOAuthService } from "./getOAuthService";
 import { showAllocationModeDialog } from "./showAllocationModeDialog";
 import { showInputRangeDialog } from "./showInputRangeDialog";
 import { generateThemesFlow } from "./generateThemes";
+import { splitIntoSentencesFlow } from './splitIntoSentences';
+import { splitIntoTokensFlow } from './splitIntoTokens';
+import { countWordsFlow } from './countWords';
+import { matrixThemesAutomatic } from './matrixThemesAutomatic';
+import { matrixThemesFromSet } from './matrixThemesFromSet';
+import { similarityMatrixThemesAutomatic } from './similarityMatrixThemesAutomatic';
+import { similarityMatrixThemesFromSet } from './similarityMatrixThemesFromSet';
 
 const mapStatusToStatusText = {
     200: 'OK',
@@ -102,6 +109,16 @@ export function onOpen() {
             .addItem('Allocate', 'clickAllocateThemes')
             .addItem('Manage', 'showManageThemesDialog');
         pulseMenu.addSubMenu(themesMenu);
+        const advancedMenu = ui
+            .createMenu('Advanced')
+            .addItem('Split Sentences', 'splitSentencesCurrent')
+            .addItem('Split Tokens', 'splitTokensCurrent')
+            .addItem('Count Words', 'countWordsCurrent')
+            .addItem('Matrix Allocate', 'matrixThemesAutomaticCurrent')
+            .addItem('Matrix From Set', 'matrixThemesFromSetPrompt')
+            .addItem('Similarity Matrix', 'similarityMatrixThemesAutomaticCurrent')
+            .addItem('Similarity From Set', 'similarityMatrixThemesFromSetPrompt');
+        pulseMenu.addSubMenu(advancedMenu);
         pulseMenu.addSeparator();
     }
     // Always include settings
@@ -128,6 +145,50 @@ export function clickAllocateThemes() {
  */
 export function clickAnalyzeSentiment() {
     showInputRangeDialog('sentiment');
+}
+
+export function splitSentencesCurrent() {
+    const range = getActiveRangeA1Notation();
+    splitIntoSentencesFlow(range);
+}
+
+export function splitTokensCurrent() {
+    const range = getActiveRangeA1Notation();
+    splitIntoTokensFlow(range);
+}
+
+export function countWordsCurrent() {
+    const range = getActiveRangeA1Notation();
+    countWordsFlow(range);
+}
+
+export function matrixThemesAutomaticCurrent() {
+    const range = getActiveRangeA1Notation();
+    matrixThemesAutomatic(range);
+}
+
+export function matrixThemesFromSetPrompt() {
+    const ui = SpreadsheetApp.getUi();
+    const resp = ui.prompt('Theme set name');
+    if (resp.getSelectedButton() === ui.Button.OK) {
+        matrixThemesFromSet(getActiveRangeA1Notation(), resp.getResponseText());
+    }
+}
+
+export function similarityMatrixThemesAutomaticCurrent() {
+    const range = getActiveRangeA1Notation();
+    similarityMatrixThemesAutomatic(range);
+}
+
+export function similarityMatrixThemesFromSetPrompt() {
+    const ui = SpreadsheetApp.getUi();
+    const resp = ui.prompt('Theme set name');
+    if (resp.getSelectedButton() === ui.Button.OK) {
+        similarityMatrixThemesFromSet(
+            getActiveRangeA1Notation(),
+            resp.getResponseText(),
+        );
+    }
 }
 
 /**
@@ -303,3 +364,10 @@ export { generateThemesFlow } from './generateThemes'
 export { getOAuthService } from './getOAuthService'
 export { saveThemeSet } from 'pulse-common'
 export { updateMenu } from './updateMenu'
+export { splitIntoSentencesFlow } from './splitIntoSentences'
+export { splitIntoTokensFlow } from './splitIntoTokens'
+export { countWordsFlow } from './countWords'
+export { matrixThemesAutomatic } from './matrixThemesAutomatic'
+export { matrixThemesFromSet } from './matrixThemesFromSet'
+export { similarityMatrixThemesAutomatic } from './similarityMatrixThemesAutomatic'
+export { similarityMatrixThemesFromSet } from './similarityMatrixThemesFromSet'

--- a/packages/sheets/src/countWords.ts
+++ b/packages/sheets/src/countWords.ts
@@ -1,0 +1,47 @@
+import { extractInputs } from 'pulse-common/input';
+
+export function countWordsFlow(dataRange: string) {
+    const ui = SpreadsheetApp.getUi();
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+
+    const parts = dataRange.split('!');
+    const sheetName = parts[0];
+    const rangeNotation = parts.slice(1).join('!');
+    const sheet = ss.getSheetByName(sheetName);
+    if (!sheet) {
+        ui.alert(`Sheet "${sheetName}" not found.`);
+        return;
+    }
+    let rangeObj: GoogleAppsScript.Spreadsheet.Range;
+    try {
+        rangeObj = sheet.getRange(rangeNotation);
+    } catch (e) {
+        ui.alert(`Invalid range notation "${rangeNotation}".`);
+        return;
+    }
+    if (rangeObj.getNumColumns() > 1) {
+        ui.alert('Please select a single column range');
+        return;
+    }
+    const values = rangeObj.getValues();
+    const { inputs, positions } = extractInputs(values, {
+        rowOffset: rangeObj.getRow(),
+        colOffset: rangeObj.getColumn(),
+    });
+    if (inputs.length === 0) {
+        ui.alert('No text found in selected data range.');
+        return;
+    }
+    const counts = inputs.map((t) => (String(t).trim().split(/\s+/).filter(Boolean).length));
+
+    const output = ss.insertSheet(`WordCount_${Date.now()}`);
+    output.getRange(1, 1, 1, 2).setValues([[ 'Text', 'Word Count' ]]);
+    output.getRange(2, 1, values.length, 1).setValues(values.map((r) => [r[0]]));
+
+    positions.forEach((pos, idx) => {
+        const rowIdx = pos.row - rangeObj.getRow() + 2;
+        output.getRange(rowIdx, 2).setValue(counts[idx]);
+    });
+
+    ss.toast('Word count complete', 'Pulse');
+}

--- a/packages/sheets/src/matrixThemesAutomatic.ts
+++ b/packages/sheets/src/matrixThemesAutomatic.ts
@@ -1,0 +1,32 @@
+import { multiCode, ShortTheme } from 'pulse-common/themes';
+import { expandWithBlankRows } from 'pulse-common/dataUtils';
+import { generateThemesFlow } from './generateThemes';
+
+const THRESHOLD = 0.4;
+
+export async function matrixThemesAutomatic(
+    dataRange: string,
+    hasHeader = false,
+) {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const { inputs, positions, themes } = await generateThemesFlow(dataRange, hasHeader);
+    ss.toast('Theme generation complete. Building matrix...', 'Pulse');
+    const expanded = expandWithBlankRows(inputs, positions);
+    const matrix = await multiCode(expanded, themes as ShortTheme[], {
+        fast: false,
+        threshold: THRESHOLD,
+        onProgress: (m) => ss.toast(m, 'Pulse'),
+    });
+    writeMatrix(matrix, expanded, themes);
+}
+
+function writeMatrix(matrix: (number|boolean)[][], inputs: string[], themes: ShortTheme[]) {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const sheet = ss.insertSheet(`Allocation_${Date.now()}`);
+    const header = ['Text', ...themes.map((t) => t.label)];
+    sheet.getRange(1, 1, 1, header.length).setValues([header]);
+    const rows = matrix.map((row, i) => [inputs[i], ...row]);
+    if (rows.length > 0) {
+        sheet.getRange(2, 1, rows.length, rows[0].length).setValues(rows);
+    }
+}

--- a/packages/sheets/src/matrixThemesFromSet.ts
+++ b/packages/sheets/src/matrixThemesFromSet.ts
@@ -1,0 +1,59 @@
+import { multiCode, getThemeSets, ShortTheme } from 'pulse-common/themes';
+import { extractInputsWithHeader, expandWithBlankRows } from 'pulse-common/dataUtils';
+
+const THRESHOLD = 0.4;
+
+export async function matrixThemesFromSet(
+    dataRange: string,
+    name: string,
+    hasHeader = false,
+) {
+    const ui = SpreadsheetApp.getUi();
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+
+    let rangeObj: GoogleAppsScript.Spreadsheet.Range;
+    try {
+        rangeObj = ss.getRange(dataRange);
+    } catch (e) {
+        ui.alert('Error reading data range: ' + e.toString());
+        return;
+    }
+    const values = rangeObj.getValues();
+    const { header, inputs, positions } = extractInputsWithHeader(values, {
+        rowOffset: rangeObj.getRow(),
+        colOffset: rangeObj.getColumn(),
+        hasHeader,
+    });
+
+    const sets = await getThemeSets();
+    const set = sets.find((s) => s.name === name);
+    if (!set) {
+        ui.alert('Theme set not found: ' + name);
+        return;
+    }
+
+    const expanded = expandWithBlankRows(inputs, positions);
+    const matrix = await multiCode(expanded, set.themes as ShortTheme[], {
+        fast: false,
+        threshold: THRESHOLD,
+        onProgress: (m) => ss.toast(m, 'Pulse'),
+    });
+
+    writeMatrix(matrix, expanded, set.themes, header);
+}
+
+function writeMatrix(
+    matrix: (number|boolean)[][],
+    inputs: string[],
+    themes: ShortTheme[],
+    header?: string,
+) {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const sheet = ss.insertSheet(`Allocation_${Date.now()}`);
+    const headerRow = [header ?? 'Text', ...themes.map((t) => t.label)];
+    sheet.getRange(1, 1, 1, headerRow.length).setValues([headerRow]);
+    const rows = matrix.map((row, i) => [inputs[i], ...row]);
+    if (rows.length > 0) {
+        sheet.getRange(2, 1, rows.length, rows[0].length).setValues(rows);
+    }
+}

--- a/packages/sheets/src/similarityMatrixThemesAutomatic.ts
+++ b/packages/sheets/src/similarityMatrixThemesAutomatic.ts
@@ -1,0 +1,30 @@
+import { splitSimilarityMatrix, ShortTheme } from 'pulse-common/themes';
+import { expandWithBlankRows } from 'pulse-common/dataUtils';
+import { generateThemesFlow } from './generateThemes';
+
+export async function similarityMatrixThemesAutomatic(
+    dataRange: string,
+    hasHeader = false,
+) {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const { inputs, positions, themes } = await generateThemesFlow(dataRange, hasHeader);
+    ss.toast('Theme generation complete. Building matrix...', 'Pulse');
+    const expanded = expandWithBlankRows(inputs, positions);
+    const matrix = await splitSimilarityMatrix(expanded, themes as ShortTheme[], {
+        fast: false,
+        normalize: false,
+        onProgress: (m) => ss.toast(m, 'Pulse'),
+    });
+    writeMatrix(matrix, expanded, themes);
+}
+
+function writeMatrix(matrix: number[][], inputs: string[], themes: ShortTheme[]) {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const sheet = ss.insertSheet(`Similarity_${Date.now()}`);
+    const header = ['Text', ...themes.map((t) => t.label)];
+    sheet.getRange(1, 1, 1, header.length).setValues([header]);
+    const rows = matrix.map((row, i) => [inputs[i], ...row]);
+    if (rows.length > 0) {
+        sheet.getRange(2, 1, rows.length, rows[0].length).setValues(rows);
+    }
+}

--- a/packages/sheets/src/similarityMatrixThemesFromSet.ts
+++ b/packages/sheets/src/similarityMatrixThemesFromSet.ts
@@ -1,0 +1,57 @@
+import { splitSimilarityMatrix, getThemeSets, ShortTheme } from 'pulse-common/themes';
+import { extractInputsWithHeader, expandWithBlankRows } from 'pulse-common/dataUtils';
+
+export async function similarityMatrixThemesFromSet(
+    dataRange: string,
+    name: string,
+    hasHeader = false,
+) {
+    const ui = SpreadsheetApp.getUi();
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+
+    let rangeObj: GoogleAppsScript.Spreadsheet.Range;
+    try {
+        rangeObj = ss.getRange(dataRange);
+    } catch (e) {
+        ui.alert('Error reading data range: ' + e.toString());
+        return;
+    }
+    const values = rangeObj.getValues();
+    const { header, inputs, positions } = extractInputsWithHeader(values, {
+        rowOffset: rangeObj.getRow(),
+        colOffset: rangeObj.getColumn(),
+        hasHeader,
+    });
+
+    const sets = await getThemeSets();
+    const set = sets.find((s) => s.name === name);
+    if (!set) {
+        ui.alert('Theme set not found: ' + name);
+        return;
+    }
+
+    const expanded = expandWithBlankRows(inputs, positions);
+    const matrix = await splitSimilarityMatrix(expanded, set.themes as ShortTheme[], {
+        fast: false,
+        normalize: false,
+        onProgress: (m) => ss.toast(m, 'Pulse'),
+    });
+
+    writeMatrix(matrix, expanded, set.themes, header);
+}
+
+function writeMatrix(
+    matrix: number[][],
+    inputs: string[],
+    themes: ShortTheme[],
+    header?: string,
+) {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const sheet = ss.insertSheet(`Similarity_${Date.now()}`);
+    const headerRow = [header ?? 'Text', ...themes.map((t) => t.label)];
+    sheet.getRange(1, 1, 1, headerRow.length).setValues([headerRow]);
+    const rows = matrix.map((row, i) => [inputs[i], ...row]);
+    if (rows.length > 0) {
+        sheet.getRange(2, 1, rows.length, rows[0].length).setValues(rows);
+    }
+}

--- a/packages/sheets/src/splitIntoSentences.ts
+++ b/packages/sheets/src/splitIntoSentences.ts
@@ -1,0 +1,58 @@
+import { extractInputs } from 'pulse-common/input';
+
+export function splitIntoSentencesFlow(dataRange: string) {
+    const ui = SpreadsheetApp.getUi();
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+
+    const parts = dataRange.split('!');
+    const sheetName = parts[0];
+    const rangeNotation = parts.slice(1).join('!');
+    const sheet = ss.getSheetByName(sheetName);
+    if (!sheet) {
+        ui.alert(`Sheet "${sheetName}" not found.`);
+        return;
+    }
+    let rangeObj: GoogleAppsScript.Spreadsheet.Range;
+    try {
+        rangeObj = sheet.getRange(rangeNotation);
+    } catch (e) {
+        ui.alert(`Invalid range notation "${rangeNotation}".`);
+        return;
+    }
+    if (rangeObj.getNumColumns() > 1) {
+        ui.alert('Please select a single column range');
+        return;
+    }
+    const values = rangeObj.getValues();
+    const { inputs, positions } = extractInputs(values, {
+        rowOffset: rangeObj.getRow(),
+        colOffset: rangeObj.getColumn(),
+    });
+    if (inputs.length === 0) {
+        ui.alert('No text found in selected data range.');
+        return;
+    }
+    // @ts-ignore
+    const segmenter = new Intl.Segmenter('en', { granularity: 'sentence' });
+    const sentences: string[][] = inputs.map((input) =>
+        Array.from(segmenter.segment(input ?? '')).map((s) => s.segment.trim()).filter(Boolean),
+    );
+    const max = Math.max(...sentences.map((s) => s.length));
+
+    const output = ss.insertSheet(`Sentences_${Date.now()}`);
+    const header = ['Text'];
+    for (let i = 0; i < max; i++) {
+        header.push(`Sentence ${i + 1}`);
+    }
+    output.getRange(1, 1, 1, header.length).setValues([header]);
+    output.getRange(2, 1, values.length, 1).setValues(values.map((r) => [r[0]]));
+
+    positions.forEach((pos, idx) => {
+        const rowIdx = pos.row - rangeObj.getRow() + 2;
+        sentences[idx].forEach((sentence, j) => {
+            output.getRange(rowIdx, j + 2).setValue(sentence);
+        });
+    });
+
+    ss.toast('Sentence split complete', 'Pulse');
+}

--- a/packages/sheets/src/splitIntoTokens.ts
+++ b/packages/sheets/src/splitIntoTokens.ts
@@ -1,0 +1,60 @@
+import { extractInputs } from 'pulse-common/input';
+
+export function splitIntoTokensFlow(dataRange: string) {
+    const ui = SpreadsheetApp.getUi();
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+
+    const parts = dataRange.split('!');
+    const sheetName = parts[0];
+    const rangeNotation = parts.slice(1).join('!');
+    const sheet = ss.getSheetByName(sheetName);
+    if (!sheet) {
+        ui.alert(`Sheet "${sheetName}" not found.`);
+        return;
+    }
+    let rangeObj: GoogleAppsScript.Spreadsheet.Range;
+    try {
+        rangeObj = sheet.getRange(rangeNotation);
+    } catch (e) {
+        ui.alert(`Invalid range notation "${rangeNotation}".`);
+        return;
+    }
+    if (rangeObj.getNumColumns() > 1) {
+        ui.alert('Please select a single column range');
+        return;
+    }
+    const values = rangeObj.getValues();
+    const { inputs, positions } = extractInputs(values, {
+        rowOffset: rangeObj.getRow(),
+        colOffset: rangeObj.getColumn(),
+    });
+    if (inputs.length === 0) {
+        ui.alert('No text found in selected data range.');
+        return;
+    }
+    // @ts-ignore
+    const segmenter = new Intl.Segmenter('en', { granularity: 'word' });
+    const tokens: string[][] = inputs.map((input) =>
+        Array.from(segmenter.segment(input ?? ''))
+            .map((s) => s.segment.trim())
+            .filter(Boolean),
+    );
+    const max = Math.max(...tokens.map((t) => t.length));
+
+    const output = ss.insertSheet(`Tokens_${Date.now()}`);
+    const header = ['Text'];
+    for (let i = 0; i < max; i++) {
+        header.push(`Token ${i + 1}`);
+    }
+    output.getRange(1, 1, 1, header.length).setValues([header]);
+    output.getRange(2, 1, values.length, 1).setValues(values.map((r) => [r[0]]));
+
+    positions.forEach((pos, idx) => {
+        const rowIdx = pos.row - rangeObj.getRow() + 2;
+        tokens[idx].forEach((token, j) => {
+            output.getRange(rowIdx, j + 2).setValue(token);
+        });
+    });
+
+    ss.toast('Token split complete', 'Pulse');
+}

--- a/packages/sheets/src/updateMenu.ts
+++ b/packages/sheets/src/updateMenu.ts
@@ -7,13 +7,23 @@ export function updateMenu() {
     const ui = SpreadsheetApp.getUi();
     const pulseMenu = ui.createMenu('Pulse');
     if (isAuthorized()) {
-        pulseMenu.addItem('Analyze Sentiment', 'analyzeSentiment');
+        pulseMenu.addItem('Analyze Sentiment', 'clickAnalyzeSentiment');
         const themesMenu = ui
             .createMenu('Themes')
-            .addItem('Generate', 'generateThemes')
-            .addItem('Allocate', 'allocateThemes')
+            .addItem('Generate', 'clickGenerateThemes')
+            .addItem('Allocate', 'clickAllocateThemes')
             .addItem('Manage', 'showManageThemesDialog');
         pulseMenu.addSubMenu(themesMenu);
+        const adv = ui
+            .createMenu('Advanced')
+            .addItem('Split Sentences', 'splitSentencesCurrent')
+            .addItem('Split Tokens', 'splitTokensCurrent')
+            .addItem('Count Words', 'countWordsCurrent')
+            .addItem('Matrix Allocate', 'matrixThemesAutomaticCurrent')
+            .addItem('Matrix From Set', 'matrixThemesFromSetPrompt')
+            .addItem('Similarity Matrix', 'similarityMatrixThemesAutomaticCurrent')
+            .addItem('Similarity From Set', 'similarityMatrixThemesFromSetPrompt');
+        pulseMenu.addSubMenu(adv);
         pulseMenu.addSeparator();
     }
     pulseMenu.addItem('Settings', 'showSettingsSidebar');


### PR DESCRIPTION
## Summary
- implement sentence/token split and word count flows for the Sheets add-on
- support matrix and similarity matrix theme allocation
- expose new actions in the menu
- test advanced Sheets flows

## Testing
- `bun run lint` *(fails: No files matching pattern & ESLint config issues)*
- `bun run test`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_b_68829287d55c8329a2b479f1b3edd0d3