### PR TITLE
Add sheet writer unit tests

### DIFF
--- a/packages/sheets/__tests__/writeAllocationsToSheet.test.ts
+++ b/packages/sheets/__tests__/writeAllocationsToSheet.test.ts
@@ -1,0 +1,40 @@
+import type { ShortTheme } from 'pulse-common';
+
+let writeAllocationsToSheet: typeof import('../src/writeAllocationsToSheet').writeAllocationsToSheet;
+
+const setValueMock = jest.fn();
+const sheetMock = {
+  getRange: jest.fn(() => ({ setValue: setValueMock })),
+};
+const toastMock = jest.fn();
+const ssMock = { toast: toastMock };
+(global as any).SpreadsheetApp = {
+  getActiveSpreadsheet: () => ssMock,
+};
+
+beforeAll(async () => {
+  writeAllocationsToSheet = (await import('../src/writeAllocationsToSheet')).writeAllocationsToSheet;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('writes labels to specified cells and toasts', () => {
+  const allocs = [
+    { theme: { label: 'A' } as ShortTheme, score: 1 },
+    { theme: { label: 'B' } as ShortTheme, score: 1 },
+  ];
+  const positions = [
+    { row: 1, col: 1 },
+    { row: 3, col: 2 },
+  ];
+
+  writeAllocationsToSheet(allocs, sheetMock as any, positions);
+
+  expect(sheetMock.getRange).toHaveBeenCalledWith(1, 2);
+  expect(sheetMock.getRange).toHaveBeenCalledWith(3, 3);
+  expect(setValueMock).toHaveBeenNthCalledWith(1, 'A');
+  expect(setValueMock).toHaveBeenNthCalledWith(2, 'B');
+  expect(toastMock).toHaveBeenCalledWith('Theme allocation complete', 'Pulse');
+});

--- a/packages/sheets/__tests__/writeThemesToSheet.test.ts
+++ b/packages/sheets/__tests__/writeThemesToSheet.test.ts
@@ -1,0 +1,60 @@
+import type { Theme } from 'pulse-common';
+
+let writeThemesToSheet: typeof import('../src/writeThemesToSheet').writeThemesToSheet;
+
+const headerRangeMock = { setValues: jest.fn() };
+const dataRangeMock = { setValues: jest.fn(), clear: jest.fn() };
+const sheetMock = {
+  getRange: jest.fn((row: number) => (row === 1 ? headerRangeMock : dataRangeMock)),
+  clear: jest.fn(),
+};
+const ssMock = {
+  getSheetByName: jest.fn(() => null),
+  insertSheet: jest.fn(() => sheetMock),
+};
+(global as any).SpreadsheetApp = {
+  getActiveSpreadsheet: () => ssMock,
+};
+
+beforeAll(async () => {
+  writeThemesToSheet = (await import('../src/writeThemesToSheet')).writeThemesToSheet;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('inserts sheet and writes headers and rows', () => {
+  const themes: Theme[] = [
+    {
+      label: 'L',
+      shortLabel: 'SL',
+      description: 'D',
+      representatives: ['r1', 'r2'],
+    },
+  ];
+
+  writeThemesToSheet(themes);
+
+  expect(ssMock.insertSheet).toHaveBeenCalledWith('Themes');
+  expect(sheetMock.clear).not.toHaveBeenCalled();
+  expect(sheetMock.getRange).toHaveBeenCalledWith(1, 1, 1, 5);
+  expect(headerRangeMock.setValues).toHaveBeenCalledWith([
+    ['Label', 'Short Label', 'Description', 'Representative 1', 'Representative 2'],
+  ]);
+  expect(sheetMock.getRange).toHaveBeenCalledWith(2, 1, 1, 5);
+  expect(dataRangeMock.setValues).toHaveBeenCalledWith([
+    ['L', 'SL', 'D', 'r1', 'r2'],
+  ]);
+});
+
+test('clears existing sheet and clears target when no rows', () => {
+  ssMock.getSheetByName.mockReturnValue(sheetMock);
+
+  writeThemesToSheet([]);
+
+  expect(ssMock.insertSheet).not.toHaveBeenCalled();
+  expect(sheetMock.clear).toHaveBeenCalled();
+  expect(headerRangeMock.setValues).toHaveBeenCalled();
+  expect(dataRangeMock.clear).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- test writeThemesToSheet inserts/clears Themes sheet
- test writeAllocationsToSheet writes theme labels to specified cells

## Testing
- `bun run lint` *(fails: No files matching the pattern `src/**/*.{ts}`)*
- `bun run test`
- `bun x jest --config jest.config.js __tests__/writeThemesToSheet.test.ts __tests__/writeAllocationsToSheet.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_68832c2cf338832990d4f0ce7d09c165