### PR TITLE
Use mapResults for sheet allocations

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,7 +17,8 @@
         "./jobs": "./src/jobs.ts",
         "./storage": "./src/storage.ts",
         "./themes": "./src/themes.ts",
-        "./dataUtils": "./src/dataUtils.ts"
+        "./dataUtils": "./src/dataUtils.ts",
+        "./output": "./src/output.ts"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/sheets/src/writeAllocationsToSheet.ts
+++ b/packages/sheets/src/writeAllocationsToSheet.ts
@@ -1,4 +1,5 @@
-import { ShortTheme, Theme } from "pulse-common";
+import { ShortTheme } from 'pulse-common';
+import { mapResults } from 'pulse-common/output';
 /**
  * Calls the similarity endpoint to assign each input to the closest theme.
  */
@@ -11,8 +12,8 @@ export function writeAllocationsToSheet(allocations: {
 
     const themes = allocations.map((a) => a.theme);
 
-    positions.forEach((pos, i) => {
-        sheet.getRange(pos.row, pos.col + 1).setValue(themes[i].label);
+    mapResults(themes, positions, (pos, theme) => {
+        sheet.getRange(pos.row, pos.col + 1).setValue(theme.label);
     });
 
     ss.toast('Theme allocation complete', 'Pulse');


### PR DESCRIPTION
## Summary
- expose `pulse-common/output`
- use `mapResults` in `writeAllocationsToSheet`

## Testing
- `bun run lint` *(fails: No files matching pattern, eslint errors)*
- `bun run test`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_b_68833e15dfd48329a851a2eeec5534e2