### PR TITLE
Add sheet activation helper for Sheets

### DIFF
--- a/packages/sheets/__tests__/advancedFlows.test.ts
+++ b/packages/sheets/__tests__/advancedFlows.test.ts
@@ -44,10 +44,14 @@ const ssMock = {
     insertSheet: jest.fn(() => newSheetMock),
     toast: jest.fn(),
 };
+const setActiveSheetMock = jest.fn();
+const sleepMock = jest.fn();
 (global as any).SpreadsheetApp = {
     getActiveSpreadsheet: () => ssMock,
     getUi: () => ({ alert: jest.fn(), prompt: () => ({ getSelectedButton: () => ({}) }) }),
+    setActiveSheet: setActiveSheetMock,
 };
+(global as any).Utilities = { sleep: sleepMock };
 
 beforeAll(async () => {
     const mod1 = await import('../src/splitIntoSentences');
@@ -68,6 +72,8 @@ beforeAll(async () => {
 
 afterEach(() => {
     jest.clearAllMocks();
+    setActiveSheetMock.mockClear();
+    sleepMock.mockClear();
 });
 
 test('splitIntoSentencesFlow creates new sheet', () => {
@@ -75,6 +81,7 @@ test('splitIntoSentencesFlow creates new sheet', () => {
     splitIntoSentencesFlow('Sheet1!A1:A2');
     expect(ssMock.insertSheet).toHaveBeenCalled();
     expect(setValuesMock).toHaveBeenCalledWith([["Text", "Sentence 1", "Sentence 2"]]);
+    expect(setActiveSheetMock).toHaveBeenCalledWith(newSheetMock);
 });
 
 test('splitIntoTokensFlow creates new sheet', () => {
@@ -82,6 +89,7 @@ test('splitIntoTokensFlow creates new sheet', () => {
     splitIntoTokensFlow('Sheet1!A1:A2');
     expect(ssMock.insertSheet).toHaveBeenCalled();
     expect(setValuesMock).toHaveBeenCalledWith([["Text", "Token 1", "Token 2"]]);
+    expect(setActiveSheetMock).toHaveBeenCalledWith(newSheetMock);
 });
 
 test('countWordsFlow writes counts', () => {
@@ -89,6 +97,7 @@ test('countWordsFlow writes counts', () => {
     countWordsFlow('Sheet1!A1:A2');
     expect(ssMock.insertSheet).toHaveBeenCalled();
     expect(setValuesMock).toHaveBeenCalledWith([["Text", "Word Count"]]);
+    expect(setActiveSheetMock).toHaveBeenCalledWith(newSheetMock);
 });
 
 test('matrixThemesAutomatic calls multiCode', async () => {
@@ -103,6 +112,7 @@ test('matrixThemesAutomatic calls multiCode', async () => {
 
     expect(multiCode).toHaveBeenCalled();
     expect(ssMock.insertSheet).toHaveBeenCalled();
+    expect(setActiveSheetMock).toHaveBeenCalledWith(newSheetMock);
 });
 
 test('matrixThemesFromSet loads theme set', async () => {
@@ -114,6 +124,7 @@ test('matrixThemesFromSet loads theme set', async () => {
 
     expect(getThemeSets).toHaveBeenCalled();
     expect(multiCode).toHaveBeenCalled();
+    expect(setActiveSheetMock).toHaveBeenCalledWith(newSheetMock);
 });
 
 test('similarityMatrixThemesAutomatic calls splitSimilarityMatrix', async () => {
@@ -128,6 +139,7 @@ test('similarityMatrixThemesAutomatic calls splitSimilarityMatrix', async () => 
 
     expect(splitSimilarityMatrix).toHaveBeenCalled();
     expect(ssMock.insertSheet).toHaveBeenCalled();
+    expect(setActiveSheetMock).toHaveBeenCalledWith(newSheetMock);
 });
 
 test('similarityMatrixThemesFromSet uses theme set', async () => {
@@ -139,4 +151,5 @@ test('similarityMatrixThemesFromSet uses theme set', async () => {
 
     expect(getThemeSets).toHaveBeenCalled();
     expect(splitSimilarityMatrix).toHaveBeenCalled();
+    expect(setActiveSheetMock).toHaveBeenCalledWith(newSheetMock);
 });

--- a/packages/sheets/__tests__/maybeActivateSheet.test.ts
+++ b/packages/sheets/__tests__/maybeActivateSheet.test.ts
@@ -1,0 +1,27 @@
+import { maybeActivateSheet } from '../src/maybeActivateSheet';
+
+describe('maybeActivateSheet', () => {
+  const setActiveSheet = jest.fn();
+  const sleep = jest.fn();
+  const sheet = {} as any;
+
+  beforeEach(() => {
+    (global as any).SpreadsheetApp = { setActiveSheet };
+    (global as any).Utilities = { sleep };
+    setActiveSheet.mockClear();
+    sleep.mockClear();
+  });
+
+  test('activates sheet within threshold', () => {
+    const start = Date.now();
+    maybeActivateSheet(sheet, start);
+    expect(setActiveSheet).toHaveBeenCalledWith(sheet);
+    expect(sleep).toHaveBeenCalled();
+  });
+
+  test('does not activate sheet after threshold', () => {
+    const start = Date.now() - 30000;
+    maybeActivateSheet(sheet, start);
+    expect(setActiveSheet).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sheets/src/countWords.ts
+++ b/packages/sheets/src/countWords.ts
@@ -1,8 +1,10 @@
 import { extractInputs } from 'pulse-common/input';
+import { maybeActivateSheet } from './maybeActivateSheet';
 
 export function countWordsFlow(dataRange: string) {
     const ui = SpreadsheetApp.getUi();
     const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const startTime = Date.now();
 
     const parts = dataRange.split('!');
     const sheetName = parts[0];
@@ -44,4 +46,5 @@ export function countWordsFlow(dataRange: string) {
     });
 
     ss.toast('Word count complete', 'Pulse');
+    maybeActivateSheet(output, startTime);
 }

--- a/packages/sheets/src/generateThemes.ts
+++ b/packages/sheets/src/generateThemes.ts
@@ -10,6 +10,7 @@ export async function generateThemesFlow(
 ) {
     const ui = SpreadsheetApp.getUi();
     const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const startTime = Date.now();
     ss.toast('Starting theme generation...', 'Pulse');
 
     let dataRangeObj: GoogleAppsScript.Spreadsheet.Range;
@@ -68,7 +69,7 @@ export async function generateThemesFlow(
         'yyyy-MM-dd HH:mm:ss',
     );
     saveThemeSet(timestamp, themesResponse.themes);
-    await writeThemes(themesResponse.themes);
+    await writeThemes(themesResponse.themes, startTime);
 
     ss.toast('Theme generation complete', 'Pulse');
 

--- a/packages/sheets/src/matrixThemesFromSet.ts
+++ b/packages/sheets/src/matrixThemesFromSet.ts
@@ -1,5 +1,6 @@
 import { multiCode, getThemeSets, ShortTheme } from 'pulse-common/themes';
 import { extractInputsWithHeader, expandWithBlankRows } from 'pulse-common/dataUtils';
+import { maybeActivateSheet } from './maybeActivateSheet';
 
 const THRESHOLD = 0.4;
 
@@ -10,6 +11,7 @@ export async function matrixThemesFromSet(
 ) {
     const ui = SpreadsheetApp.getUi();
     const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const startTime = Date.now();
 
     let rangeObj: GoogleAppsScript.Spreadsheet.Range;
     try {
@@ -39,15 +41,16 @@ export async function matrixThemesFromSet(
         onProgress: (m) => ss.toast(m, 'Pulse'),
     });
 
-    writeMatrix(matrix, expanded, set.themes, header);
+    const sheet = writeMatrix(matrix, expanded, set.themes, header);
+    maybeActivateSheet(sheet, startTime);
 }
 
 function writeMatrix(
-    matrix: (number|boolean)[][],
+    matrix: (number | boolean)[][],
     inputs: string[],
     themes: ShortTheme[],
     header?: string,
-) {
+): GoogleAppsScript.Spreadsheet.Sheet {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     const sheet = ss.insertSheet(`Allocation_${Date.now()}`);
     const headerRow = [header ?? 'Text', ...themes.map((t) => t.label)];
@@ -56,4 +59,5 @@ function writeMatrix(
     if (rows.length > 0) {
         sheet.getRange(2, 1, rows.length, rows[0].length).setValues(rows);
     }
+    return sheet;
 }

--- a/packages/sheets/src/maybeActivateSheet.ts
+++ b/packages/sheets/src/maybeActivateSheet.ts
@@ -1,0 +1,10 @@
+export function maybeActivateSheet(
+    sheet: GoogleAppsScript.Spreadsheet.Sheet,
+    startTime: number,
+    thresholdMs = 20000,
+): void {
+    if (Date.now() - startTime <= thresholdMs) {
+        SpreadsheetApp.setActiveSheet(sheet);
+        Utilities.sleep(50);
+    }
+}

--- a/packages/sheets/src/similarityMatrixThemesFromSet.ts
+++ b/packages/sheets/src/similarityMatrixThemesFromSet.ts
@@ -1,5 +1,6 @@
 import { splitSimilarityMatrix, getThemeSets, ShortTheme } from 'pulse-common/themes';
 import { extractInputsWithHeader, expandWithBlankRows } from 'pulse-common/dataUtils';
+import { maybeActivateSheet } from './maybeActivateSheet';
 
 export async function similarityMatrixThemesFromSet(
     dataRange: string,
@@ -8,6 +9,7 @@ export async function similarityMatrixThemesFromSet(
 ) {
     const ui = SpreadsheetApp.getUi();
     const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const startTime = Date.now();
 
     let rangeObj: GoogleAppsScript.Spreadsheet.Range;
     try {
@@ -37,7 +39,8 @@ export async function similarityMatrixThemesFromSet(
         onProgress: (m) => ss.toast(m, 'Pulse'),
     });
 
-    writeMatrix(matrix, expanded, set.themes, header);
+    const sheet = writeMatrix(matrix, expanded, set.themes, header);
+    maybeActivateSheet(sheet, startTime);
 }
 
 function writeMatrix(
@@ -45,7 +48,7 @@ function writeMatrix(
     inputs: string[],
     themes: ShortTheme[],
     header?: string,
-) {
+): GoogleAppsScript.Spreadsheet.Sheet {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     const sheet = ss.insertSheet(`Similarity_${Date.now()}`);
     const headerRow = [header ?? 'Text', ...themes.map((t) => t.label)];
@@ -54,4 +57,5 @@ function writeMatrix(
     if (rows.length > 0) {
         sheet.getRange(2, 1, rows.length, rows[0].length).setValues(rows);
     }
+    return sheet;
 }

--- a/packages/sheets/src/splitIntoSentences.ts
+++ b/packages/sheets/src/splitIntoSentences.ts
@@ -1,8 +1,10 @@
 import { extractInputs } from 'pulse-common/input';
+import { maybeActivateSheet } from './maybeActivateSheet';
 
 export function splitIntoSentencesFlow(dataRange: string) {
     const ui = SpreadsheetApp.getUi();
     const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const startTime = Date.now();
 
     const parts = dataRange.split('!');
     const sheetName = parts[0];
@@ -55,4 +57,5 @@ export function splitIntoSentencesFlow(dataRange: string) {
     });
 
     ss.toast('Sentence split complete', 'Pulse');
+    maybeActivateSheet(output, startTime);
 }

--- a/packages/sheets/src/splitIntoTokens.ts
+++ b/packages/sheets/src/splitIntoTokens.ts
@@ -1,8 +1,10 @@
 import { extractInputs } from 'pulse-common/input';
+import { maybeActivateSheet } from './maybeActivateSheet';
 
 export function splitIntoTokensFlow(dataRange: string) {
     const ui = SpreadsheetApp.getUi();
     const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const startTime = Date.now();
 
     const parts = dataRange.split('!');
     const sheetName = parts[0];
@@ -57,4 +59,5 @@ export function splitIntoTokensFlow(dataRange: string) {
     });
 
     ss.toast('Token split complete', 'Pulse');
+    maybeActivateSheet(output, startTime);
 }

--- a/packages/sheets/src/writeThemes.ts
+++ b/packages/sheets/src/writeThemes.ts
@@ -1,7 +1,8 @@
-import { Theme } from "pulse-common";
-import { themesToRows } from "pulse-common/dataUtils";
+import { Theme } from 'pulse-common';
+import { themesToRows } from 'pulse-common/dataUtils';
+import { maybeActivateSheet } from './maybeActivateSheet';
 
-export function writeThemes(themes: Theme[]) {
+export function writeThemes(themes: Theme[], startTime?: number): GoogleAppsScript.Spreadsheet.Sheet {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     // Log full themes info to 'Themes' worksheet
     let outputSheet = ss.getSheetByName('Themes');
@@ -22,4 +23,8 @@ export function writeThemes(themes: Theme[]) {
     if (rows.length > 0) {
         outputSheet.getRange(2, 1, rows.length, headers.length).setValues(rows);
     }
+    if (typeof startTime === 'number') {
+        maybeActivateSheet(outputSheet, startTime);
+    }
+    return outputSheet;
 }

--- a/packages/sheets/src/writeThemesToSheet.ts
+++ b/packages/sheets/src/writeThemesToSheet.ts
@@ -1,7 +1,11 @@
 import type { Theme } from 'pulse-common';
 import { themesToRows } from 'pulse-common/dataUtils';
+import { maybeActivateSheet } from './maybeActivateSheet';
 
-export function writeThemesToSheet(themes: Theme[]) {
+export function writeThemesToSheet(
+    themes: Theme[],
+    startTime?: number,
+): GoogleAppsScript.Spreadsheet.Sheet {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     let sheet = ss.getSheetByName('Themes');
     if (!sheet) {
@@ -25,4 +29,8 @@ export function writeThemesToSheet(themes: Theme[]) {
     } else {
         target.clear();
     }
+    if (typeof startTime === 'number') {
+        maybeActivateSheet(sheet, startTime);
+    }
+    return sheet;
 }


### PR DESCRIPTION
## Summary
- add `maybeActivateSheet` helper for Sheets
- call helper after creating new sheets
- ensure tests cover sheet activation logic

## Testing
- `bun run lint` *(fails: No files matching pattern)*
- `bun run build`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_68833e2141c883298fca1b5cec944c81