### PR TITLE
Share theme sheet writer

### DIFF
--- a/packages/common/__tests__/saveThemesToSheet.test.ts
+++ b/packages/common/__tests__/saveThemesToSheet.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'bun:test';
+import { saveThemesToSheet } from '../src/saveThemesToSheet';
+import type { Theme } from '../src/apiClient';
+
+interface MockSheet {
+  writes: Array<{ range: string; values: string[][] }>;
+  cleared: boolean;
+}
+
+describe('saveThemesToSheet', () => {
+  const headers = [
+    'Label',
+    'Short Label',
+    'Description',
+    'Representative 1',
+    'Representative 2',
+  ];
+
+  const themes: Theme[] = [
+    {
+      label: 'L',
+      shortLabel: 'SL',
+      description: 'D',
+      representatives: ['r1', 'r2'],
+    },
+  ];
+
+  it('writes headers and rows via adapter', async () => {
+    const sheet: MockSheet = { writes: [], cleared: false };
+    await saveThemesToSheet({
+      themes,
+      addSheet: () => sheet,
+      clearSheet: (s) => {
+        s.cleared = true;
+      },
+      write: (s, range, values) => {
+        s.writes.push({ range, values });
+      },
+    });
+    expect(sheet.cleared).toBe(true);
+    expect(sheet.writes[0]).toEqual({ range: 'A1:E1', values: [headers] });
+    expect(sheet.writes[1]).toEqual({ range: 'A2:E2', values: [
+      ['L', 'SL', 'D', 'r1', 'r2'],
+    ] });
+  });
+});

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,7 +18,8 @@
         "./storage": "./src/storage.ts",
         "./themes": "./src/themes.ts",
         "./dataUtils": "./src/dataUtils.ts",
-        "./output": "./src/output.ts"
+        "./output": "./src/output.ts",
+        "./saveThemesToSheet": "./src/saveThemesToSheet.ts"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -12,3 +12,4 @@ export * from './pkce.js';
 export * from './org.js';
 export * from './storage.js';
 export * from './dataUtils.js';
+export * from './saveThemesToSheet.js';

--- a/packages/common/src/saveThemesToSheet.ts
+++ b/packages/common/src/saveThemesToSheet.ts
@@ -1,0 +1,33 @@
+import type { Theme } from './apiClient';
+import { themesToRows } from './dataUtils';
+
+export interface SaveThemesAdapter<SheetLike = any> {
+    themes: Theme[];
+    addSheet(name: string): SheetLike | Promise<SheetLike>;
+    clearSheet(sheet: SheetLike): void | Promise<void>;
+    write(sheet: SheetLike, range: string, values: string[][]): void | Promise<void>;
+}
+
+export async function saveThemesToSheet<SheetLike>(
+    opts: SaveThemesAdapter<SheetLike>,
+): Promise<SheetLike> {
+    const { themes, addSheet, clearSheet, write } = opts;
+    const sheet = await addSheet('Themes');
+    await clearSheet(sheet);
+
+    const headers = [
+        'Label',
+        'Short Label',
+        'Description',
+        'Representative 1',
+        'Representative 2',
+    ];
+    await write(sheet, 'A1:E1', [headers]);
+
+    const rows = themesToRows(themes);
+    const end = rows.length + 1;
+    const range = `A2:E${end}`;
+    await write(sheet, range, rows);
+
+    return sheet;
+}

--- a/packages/excel/src/services/saveThemesToSheet.ts
+++ b/packages/excel/src/services/saveThemesToSheet.ts
@@ -1,5 +1,5 @@
 import type { Theme } from 'pulse-common';
-import { themesToRows } from 'pulse-common/dataUtils';
+import { saveThemesToSheet as saveCommon } from 'pulse-common/saveThemesToSheet';
 
 interface Props {
     themes: Theme[];
@@ -7,44 +7,38 @@ interface Props {
 }
 
 export async function saveThemesToSheet({ context, themes }: Props) {
-    const themesSheetName = 'Themes';
-    let themesSheet;
-    try {
-        console.log('Creating new themes sheet');
-        themesSheet = context.workbook.worksheets.add(themesSheetName);
-        await context.sync();
-    } catch (e) {
-        themesSheet = context.workbook.worksheets.getItem(themesSheetName);
-        console.log('Themes sheet already exists');
-        themesSheet.getUsedRange().clear();
-        await context.sync();
-        console.log('Cleared existing themes sheet');
-    }
-    console.log('Themes sheet', themesSheet);
-    themesSheet.getRange('A1:E1').values = [
-        [
-            'Label',
-            'Short Label',
-            'Description',
-            'Representative 1',
-            'Representative 2',
-        ],
-    ];
-    themesSheet.getRange('A1:E1').format.autofitColumns();
-    themesSheet.getRange('A1:E1').format.fill.color = '#D9EAD3';
-    themesSheet.getRange('A1:E1').format.font.bold = true;
-    themesSheet.getRange('A1:E1').format.horizontalAlignment =
-        Excel.HorizontalAlignment.center;
-
-    themesSheet.getRange('A1:E1').format.borders.getItem('EdgeBottom').style =
-        Excel.BorderLineStyle.double;
-
-    await context.sync();
-
-    const themesArr = themesToRows(themes);
-    console.log('Range', `A2:E${themesArr.length + 1}`);
-    themesSheet.getRange(`A2:E${themesArr.length + 1}`).values = themesArr;
-    themesSheet.getRange(`A2:E${themesArr.length + 1}`).format.autofitColumns();
-
-    await context.sync();
+    let existed = true;
+    await saveCommon({
+        themes,
+        async addSheet(name) {
+            try {
+                const sheet = context.workbook.worksheets.add(name);
+                await context.sync();
+                existed = false;
+                return sheet;
+            } catch (e) {
+                const sheet = context.workbook.worksheets.getItem(name);
+                return sheet;
+            }
+        },
+        async clearSheet(sheet) {
+            if (existed) {
+                sheet.getUsedRange().clear();
+                await context.sync();
+            }
+        },
+        async write(sheet, range, values) {
+            const r = sheet.getRange(range);
+            r.values = values;
+            r.format.autofitColumns();
+            if (range === 'A1:E1') {
+                r.format.fill.color = '#D9EAD3';
+                r.format.font.bold = true;
+                r.format.horizontalAlignment = Excel.HorizontalAlignment.center;
+                r.format.borders.getItem('EdgeBottom').style =
+                    Excel.BorderLineStyle.double;
+            }
+            await context.sync();
+        },
+    });
 }

--- a/packages/sheets/__tests__/writeThemesToSheet.test.ts
+++ b/packages/sheets/__tests__/writeThemesToSheet.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-test('inserts sheet and writes headers and rows', () => {
+test('inserts sheet and writes headers and rows', async () => {
   const themes: Theme[] = [
     {
       label: 'L',
@@ -34,7 +34,7 @@ test('inserts sheet and writes headers and rows', () => {
     },
   ];
 
-  writeThemesToSheet(themes);
+  await writeThemesToSheet(themes);
 
   expect(ssMock.insertSheet).toHaveBeenCalledWith('Themes');
   expect(sheetMock.clear).not.toHaveBeenCalled();
@@ -48,10 +48,10 @@ test('inserts sheet and writes headers and rows', () => {
   ]);
 });
 
-test('clears existing sheet and clears target when no rows', () => {
+test('clears existing sheet and clears target when no rows', async () => {
   ssMock.getSheetByName.mockReturnValue(sheetMock);
 
-  writeThemesToSheet([]);
+  await writeThemesToSheet([]);
 
   expect(ssMock.insertSheet).not.toHaveBeenCalled();
   expect(sheetMock.clear).toHaveBeenCalled();

--- a/packages/sheets/src/writeThemesToSheet.ts
+++ b/packages/sheets/src/writeThemesToSheet.ts
@@ -1,34 +1,44 @@
 import type { Theme } from 'pulse-common';
-import { themesToRows } from 'pulse-common/dataUtils';
+import { saveThemesToSheet as saveCommon } from 'pulse-common/saveThemesToSheet';
 import { maybeActivateSheet } from './maybeActivateSheet';
 
-export function writeThemesToSheet(
+export async function writeThemesToSheet(
     themes: Theme[],
     startTime?: number,
-): GoogleAppsScript.Spreadsheet.Sheet {
+): Promise<GoogleAppsScript.Spreadsheet.Sheet> {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
-    let sheet = ss.getSheetByName('Themes');
-    if (!sheet) {
-        sheet = ss.insertSheet('Themes');
-    } else {
-        sheet.clear();
-    }
+    let existed = true;
+    const sheet = await saveCommon({
+        themes,
+        addSheet(name) {
+            let s = ss.getSheetByName(name);
+            if (!s) {
+                existed = false;
+                s = ss.insertSheet(name);
+            }
+            return s;
+        },
+        clearSheet(s) {
+            if (existed) {
+                s.clear();
+            }
+        },
+        write(s, range, values) {
+            if (range === 'A1:E1') {
+                s.getRange(1, 1, 1, 5).setValues(values);
+            } else if (range.startsWith('A2:E')) {
+                const end = Number(range.slice(4));
+                const rows = end - 1;
+                const target = s.getRange(2, 1, rows, 5);
+                if (values.length > 0) {
+                    target.setValues(values);
+                } else {
+                    target.clear();
+                }
+            }
+        },
+    });
 
-    const headers = [
-        'Label',
-        'Short Label',
-        'Description',
-        'Representative 1',
-        'Representative 2',
-    ];
-    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
-    const rows = themesToRows(themes);
-    const target = sheet.getRange(2, 1, rows.length, headers.length);
-    if (rows.length > 0) {
-        target.setValues(rows);
-    } else {
-        target.clear();
-    }
     if (typeof startTime === 'number') {
         maybeActivateSheet(sheet, startTime);
     }


### PR DESCRIPTION
## Summary
- add shared `saveThemesToSheet` helper in `pulse-common`
- expose helper from common entrypoint
- adapt Excel and Sheets implementations to use the shared helper
- update Sheets tests for async API
- add unit test for new helper

## Testing
- `bun run lint` *(fails: No files matching the pattern)*
- `bun run test` *(fails: Test suite failed to run)*
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_b_68834252fd3083299a3aae3464ddcaf2