### PR TITLE
Add feed sidebar and integrate with Sheets flows

### DIFF
--- a/packages/sheets/__tests__/feedToast.test.ts
+++ b/packages/sheets/__tests__/feedToast.test.ts
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+
+const updateItem = jest.fn();
+const getFeed = jest.fn(() => [{ jobId: '1' }]);
+
+jest.mock('pulse-common/jobs', () => ({
+  updateItem: (...args: any[]) => updateItem(...args),
+  getFeed: (...args: any[]) => getFeed(...args),
+}));
+
+let feedToast: typeof import('../src/feedToast').feedToast;
+
+beforeAll(async () => {
+  feedToast = (await import('../src/feedToast')).feedToast;
+});
+
+beforeEach(() => {
+  (global as any).SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({ toast: jest.fn() }),
+  };
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('updates feed with last item', () => {
+  feedToast('hello');
+  const toast = (SpreadsheetApp.getActiveSpreadsheet() as any).toast;
+  expect(toast).toHaveBeenCalledWith('hello', 'Pulse');
+  expect(updateItem).toHaveBeenCalledWith({ jobId: '1', message: 'hello' });
+});

--- a/packages/sheets/__tests__/writeAllocationsToSheet.test.ts
+++ b/packages/sheets/__tests__/writeAllocationsToSheet.test.ts
@@ -1,5 +1,7 @@
 import type { ShortTheme } from 'pulse-common';
 
+jest.mock('../src/feedToast', () => ({ feedToast: jest.fn() }));
+
 let writeAllocationsToSheet: typeof import('../src/writeAllocationsToSheet').writeAllocationsToSheet;
 
 const setValueMock = jest.fn();

--- a/packages/sheets/src/Code.ts
+++ b/packages/sheets/src/Code.ts
@@ -15,6 +15,7 @@ import { matrixThemesAutomatic } from './matrixThemesAutomatic';
 import { matrixThemesFromSet } from './matrixThemesFromSet';
 import { similarityMatrixThemesAutomatic } from './similarityMatrixThemesAutomatic';
 import { similarityMatrixThemesFromSet } from './similarityMatrixThemesFromSet';
+import { getFeed, getItem } from 'pulse-common/jobs';
 
 const mapStatusToStatusText = {
     200: 'OK',
@@ -122,6 +123,7 @@ export function onOpen() {
         pulseMenu.addSeparator();
     }
     // Always include settings
+    pulseMenu.addItem('Feed', 'showFeedSidebar');
     pulseMenu.addItem('Settings', 'showSettingsSidebar');
     pulseMenu.addToUi();
 }
@@ -302,6 +304,20 @@ export function showSettingsSidebar() {
     template.webBase = WEB_BASE;
     const html = template.evaluate().setTitle('Pulse');
     SpreadsheetApp.getUi().showSidebar(html);
+}
+
+export function showFeedSidebar() {
+    const html = HtmlService.createHtmlOutputFromFile('Feed').setTitle('Pulse');
+    SpreadsheetApp.getUi().showSidebar(html);
+}
+
+export function getFeedItems() {
+    return getFeed().map((item) => ({ ...item, onClick: Boolean(item.onClick) }));
+}
+
+export function runFeedOnClick(jobId: string) {
+    const item = getItem(jobId);
+    item?.onClick?.();
 }
 /**
  * Retrieves stored user email and authorization status.

--- a/packages/sheets/src/Feed.html
+++ b/packages/sheets/src/Feed.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base target="_top">
+  <style>
+    body { font-family: Arial, sans-serif; margin:0; padding:10px; background:#f3f2f1; }
+    .item { background:#fff; margin-bottom:8px; padding:8px; border-left:4px solid #ccc; cursor:default; }
+    .item.completed { border-color:#4caf50; }
+    .item.failed { border-color:#f44336; }
+    .item.in-progress { border-color:#9c27b0; }
+    .item.waiting { border-color:#9e9e9e; }
+    .item.clickable { cursor:pointer; text-decoration:underline; }
+  </style>
+</head>
+<body>
+  <h5>Feed</h5>
+  <div id="feed"></div>
+  <script>
+    function css(status){
+      return status.replace(/_/g,'-');
+    }
+    function render(items){
+      const feed = document.getElementById('feed');
+      feed.innerHTML='';
+      items.forEach(it=>{
+        const div=document.createElement('div');
+        div.className='item '+css(it.status)+(it.onClick? ' clickable':'');
+        div.textContent=it.title+(it.message?': '+it.message:'');
+        if(it.onClick){
+          div.addEventListener('click',()=>{
+            google.script.run.runFeedOnClick(it.jobId);
+          });
+        }
+        feed.appendChild(div);
+      });
+    }
+    function poll(){
+      google.script.run.withSuccessHandler(render).getFeedItems();
+    }
+    poll();
+    setInterval(poll,1000);
+  </script>
+</body>
+</html>

--- a/packages/sheets/src/allocateAndSaveThemeSet.ts
+++ b/packages/sheets/src/allocateAndSaveThemeSet.ts
@@ -1,5 +1,7 @@
 import { allocateThemes, extractInputs } from 'pulse-common';
 import { writeAllocationsToSheet } from './writeAllocationsToSheet';
+import { feedToast } from './feedToast';
+import { getFeed, updateItem } from 'pulse-common/jobs';
 
 /**
  * Processes custom themes after the user submits ranges via dialog.
@@ -83,10 +85,24 @@ export async function allocateAndSaveThemeSet(ranges: {
         await allocateThemes(inputs, themes, {
             fast: false,
             onProgress: (message: string) => {
-                ss.toast(message, 'Pulse');
+                feedToast(message);
             }
         }),
         dataSheet,
         positions,
     );
+
+    feedToast('Theme allocation complete');
+
+    const feed = getFeed();
+    const last = feed[feed.length - 1];
+    if (last) {
+        updateItem({
+            jobId: last.jobId,
+            onClick: () => {
+                SpreadsheetApp.setActiveSheet(dataSheet);
+            },
+            sheetName: dataSheet.getName(),
+        });
+    }
 }

--- a/packages/sheets/src/allocateThemesFromSet.ts
+++ b/packages/sheets/src/allocateThemesFromSet.ts
@@ -1,6 +1,8 @@
 import { allocateThemes } from 'pulse-common/api';
 import { extractInputsWithHeader, expandWithBlankRows } from 'pulse-common/dataUtils';
 import { getThemeSets } from 'pulse-common/themes';
+import { feedToast } from './feedToast';
+import { getFeed, updateItem } from 'pulse-common/jobs';
 
 /**
  * Allocate themes from an existing saved set.
@@ -45,7 +47,7 @@ export async function allocateThemesFromSet(
     const allocations = await allocateThemes(inputs, themes, {
         fast: false,
         onProgress: (message: string) => {
-            ss.toast(message, 'Pulse');
+            feedToast(message);
         },
     });
 
@@ -58,4 +60,18 @@ export async function allocateThemesFromSet(
     dataSheet
         .getRange(startRow, col, expanded.length, 1)
         .setValues(expanded.map((l) => [l]));
+
+    feedToast('Theme allocation complete');
+
+    const feed = getFeed();
+    const last = feed[feed.length - 1];
+    if (last) {
+        updateItem({
+            jobId: last.jobId,
+            onClick: () => {
+                SpreadsheetApp.setActiveSheet(dataSheet);
+            },
+            sheetName: dataSheet.getName(),
+        });
+    }
 }

--- a/packages/sheets/src/countWords.ts
+++ b/packages/sheets/src/countWords.ts
@@ -1,5 +1,7 @@
 import { extractInputs } from 'pulse-common/input';
 import { maybeActivateSheet } from './maybeActivateSheet';
+import { feedToast } from './feedToast';
+import { getFeed, updateItem } from 'pulse-common/jobs';
 
 export function countWordsFlow(dataRange: string) {
     const ui = SpreadsheetApp.getUi();
@@ -45,6 +47,18 @@ export function countWordsFlow(dataRange: string) {
         output.getRange(rowIdx, 2).setValue(counts[idx]);
     });
 
-    ss.toast('Word count complete', 'Pulse');
+    feedToast('Word count complete');
     maybeActivateSheet(output, startTime);
+
+    const feed = getFeed();
+    const last = feed[feed.length - 1];
+    if (last) {
+        updateItem({
+            jobId: last.jobId,
+            onClick: () => {
+                SpreadsheetApp.setActiveSheet(output);
+            },
+            sheetName: output.getName(),
+        });
+    }
 }

--- a/packages/sheets/src/feedToast.ts
+++ b/packages/sheets/src/feedToast.ts
@@ -1,0 +1,11 @@
+import { getFeed, updateItem } from 'pulse-common/jobs';
+
+export function feedToast(message: string) {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    ss.toast(message, 'Pulse');
+    const feed = getFeed();
+    const last = feed[feed.length - 1];
+    if (last) {
+        updateItem({ jobId: last.jobId, message });
+    }
+}

--- a/packages/sheets/src/splitIntoSentences.ts
+++ b/packages/sheets/src/splitIntoSentences.ts
@@ -1,5 +1,7 @@
 import { extractInputs } from 'pulse-common/input';
 import { maybeActivateSheet } from './maybeActivateSheet';
+import { feedToast } from './feedToast';
+import { getFeed, updateItem } from 'pulse-common/jobs';
 
 export function splitIntoSentencesFlow(dataRange: string) {
     const ui = SpreadsheetApp.getUi();
@@ -56,6 +58,18 @@ export function splitIntoSentencesFlow(dataRange: string) {
         });
     });
 
-    ss.toast('Sentence split complete', 'Pulse');
+    feedToast('Sentence split complete');
     maybeActivateSheet(output, startTime);
+
+    const feed = getFeed();
+    const last = feed[feed.length - 1];
+    if (last) {
+        updateItem({
+            jobId: last.jobId,
+            onClick: () => {
+                SpreadsheetApp.setActiveSheet(output);
+            },
+            sheetName: output.getName(),
+        });
+    }
 }

--- a/packages/sheets/src/splitIntoTokens.ts
+++ b/packages/sheets/src/splitIntoTokens.ts
@@ -1,5 +1,7 @@
 import { extractInputs } from 'pulse-common/input';
 import { maybeActivateSheet } from './maybeActivateSheet';
+import { feedToast } from './feedToast';
+import { getFeed, updateItem } from 'pulse-common/jobs';
 
 export function splitIntoTokensFlow(dataRange: string) {
     const ui = SpreadsheetApp.getUi();
@@ -58,6 +60,18 @@ export function splitIntoTokensFlow(dataRange: string) {
         });
     });
 
-    ss.toast('Token split complete', 'Pulse');
+    feedToast('Token split complete');
     maybeActivateSheet(output, startTime);
+
+    const feed = getFeed();
+    const last = feed[feed.length - 1];
+    if (last) {
+        updateItem({
+            jobId: last.jobId,
+            onClick: () => {
+                SpreadsheetApp.setActiveSheet(output);
+            },
+            sheetName: output.getName(),
+        });
+    }
 }

--- a/packages/sheets/src/updateMenu.ts
+++ b/packages/sheets/src/updateMenu.ts
@@ -26,6 +26,7 @@ export function updateMenu() {
         pulseMenu.addSubMenu(adv);
         pulseMenu.addSeparator();
     }
+    pulseMenu.addItem('Feed', 'showFeedSidebar');
     pulseMenu.addItem('Settings', 'showSettingsSidebar');
     pulseMenu.addToUi();
 }

--- a/packages/sheets/src/writeAllocationsToSheet.ts
+++ b/packages/sheets/src/writeAllocationsToSheet.ts
@@ -1,5 +1,7 @@
 import { ShortTheme } from 'pulse-common';
 import { mapResults } from 'pulse-common/output';
+import { feedToast } from './feedToast';
+import { getFeed, updateItem } from 'pulse-common/jobs';
 /**
  * Calls the similarity endpoint to assign each input to the closest theme.
  */
@@ -16,5 +18,17 @@ export function writeAllocationsToSheet(allocations: {
         sheet.getRange(pos.row, pos.col + 1).setValue(theme.label);
     });
 
-    ss.toast('Theme allocation complete', 'Pulse');
+    feedToast('Theme allocation complete');
+
+    const feed = getFeed();
+    const last = feed[feed.length - 1];
+    if (last) {
+        updateItem({
+            jobId: last.jobId,
+            onClick: () => {
+                SpreadsheetApp.setActiveSheet(sheet);
+            },
+            sheetName: sheet.getName(),
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- add feed sidebar HTML and helper for updating feed
- expose sidebar functions in Sheets code and Pulse menu
- update all Sheets flows to use feedToast for progress and feed updates
- add unit tests for feedToast

## Testing
- `bun run lint` *(fails: No files matching the pattern)*
- `bun run test`
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_b_6883425462f88329878abed087d80f54