### PR TITLE
Implement fast sentiment flow with feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ This repository contains multiple packages managed with **Bun workspaces**. Foll
   ```bash
   bun run lint
   ```
+- **Type check all packages**:
+  ```bash
+  bun run typecheck
+  ```
 - **Run tests**:
   ```bash
   bun run test
@@ -34,6 +38,6 @@ This repository contains multiple packages managed with **Bun workspaces**. Foll
 ## Contribution rules
 - Use Bun for all installs and script execution.
 - Do **not** commit `dist/`, `node_modules/`, or `.git/` directories.
-- Ensure linting, tests, and builds succeed before opening a pull request.
+- Ensure linting, type checks, tests, and builds succeed before opening a pull request.
 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "bootstrap": "bun install",
     "build": "bun run --filter '*' build",
     "test": "bun run --filter '*' test",
-    "lint": "bun run --filter '*' lint"
+    "lint": "bun run --filter '*' lint",
+    "typecheck": "bun run --filter=pulse-common typecheck"
   },
   "devDependencies": {
     "generator-office": "^3.0.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -25,6 +25,7 @@
         "build": "tsc -b",
         "test": "bun test",
         "lint": "eslint src --ext .ts",
+        "typecheck": "tsc --noEmit",
         "prepublishOnly": "bun run build"
     },
     "devDependencies": {

--- a/packages/excel/package.json
+++ b/packages/excel/package.json
@@ -8,6 +8,7 @@
         "dev-server": "webpack serve --mode development",
         "lint": "office-addin-lint check",
         "lint:fix": "office-addin-lint fix",
+        "typecheck": "tsc --noEmit",
         "prestart": "npm run build",
         "prettier": "office-addin-lint prettier",
         "signin": "office-addin-dev-settings m365-account login",

--- a/packages/excel/tsconfig.json
+++ b/packages/excel/tsconfig.json
@@ -4,6 +4,7 @@
         "baseUrl": ".",
         "esModuleInterop": true,
         "experimentalDecorators": true,
+        "module": "NodeNext",
         "moduleResolution": "nodenext",
         "jsx": "react-jsx",
         "noEmitOnError": true,


### PR DESCRIPTION
## Summary
- write sentiment results to a new sheet like Excel
- open the feed automatically on long jobs
- update tests for new sentiment workflow
- add workspace typecheck script and document it

## Testing
- `bun run lint` *(fails: No files matching pattern and eslint config issues)*
- `bun run test`
- `bun run build`
- `bun run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_688361be13788329853e6ceba6d9c742