### PR TITLE
Update Sheets menu with theme source dialog

### DIFF
--- a/packages/sheets/src/AllocationModeDialog.html
+++ b/packages/sheets/src/AllocationModeDialog.html
@@ -17,6 +17,7 @@
     </head>
     <body class="container">
         <input id="dataRange" type="hidden" value="<?= dataRange ?>" />
+        <input id="flow" type="hidden" value="<?= flow ?>" />
         <p>
             <label>
                 <input type="checkbox" id="hasHeader" <?= hasHeader ? 'checked' : '' ?> />
@@ -27,26 +28,38 @@
             <p>
                 <label>
                     <input name="mode" type="radio" value="auto" checked />
-                    <span>Automatically Generate (one-off)</span>
+                    <span>Generate new themes automatically</span>
                 </label>
             </p>
-            <? for (var i = 0; i < themeSetNames.length; i++) { ?>
             <p>
                 <label>
-                    <input
-                        name="mode"
-                        type="radio"
-                        value="<?= themeSetNames[i] ?>"
-                    />
-                    <span>Use Theme Set "<?= themeSetNames[i] ?>"</span>
+                    <input name="mode" type="radio" value="set" />
+                    <span>Use existing theme set:</span>
                 </label>
+                <div class="input-field">
+                    <select id="setSelect" disabled>
+                        <? for (var i = 0; i < themeSetNames.length; i++) { ?>
+                            <option value="<?= themeSetNames[i] ?>">
+                                <?= themeSetNames[i] ?>
+                            </option>
+                        <? } ?>
+                    </select>
+                </div>
             </p>
-            <? } ?>
             <p>
                 <label>
-                    <input name="mode" type="radio" value="new" />
-                    <span>Create &amp; Save New Theme Set</span>
+                    <input name="mode" type="radio" value="sheet" />
+                    <span>Read theme set from sheet:</span>
                 </label>
+                <div class="input-field">
+                    <select id="sheetSelect" disabled>
+                        <? for (var i = 0; i < sheetNames.length; i++) { ?>
+                            <option value="<?= sheetNames[i] ?>">
+                                <?= sheetNames[i] ?>
+                            </option>
+                        <? } ?>
+                    </select>
+                </div>
             </p>
         </form>
         <div class="row">
@@ -68,21 +81,68 @@
         <script>
             document.addEventListener('DOMContentLoaded', function () {
                 M.AutoInit();
+                const setSelect = document.getElementById('setSelect');
+                const sheetSelect = document.getElementById('sheetSelect');
+                const modeSet = document.querySelector('input[value="set"]');
+                const modeSheet = document.querySelector('input[value="sheet"]');
+                modeSet.addEventListener('change', () => {
+                    setSelect.disabled = !modeSet.checked;
+                    sheetSelect.disabled = true;
+                });
+                modeSheet.addEventListener('change', () => {
+                    sheetSelect.disabled = !modeSheet.checked;
+                    setSelect.disabled = true;
+                });
+                document.querySelector('input[value="auto"]').addEventListener('change', () => {
+                    setSelect.disabled = true;
+                    sheetSelect.disabled = true;
+                });
             });
             function submitMode() {
                 const form = document.getElementById('modeForm');
                 const mode = form.mode.value;
                 const dr = document.getElementById('dataRange').value;
                 const hasHeader = document.getElementById('hasHeader').checked;
-                // Start the allocation job and close the dialog immediately
-                if (mode === 'new') {
-                    const name = prompt('Name for this Theme Set?');
-                    if (!name) return;
-                    google.script.run.showRangeDialog(dr, name);
-                } else if (mode === 'auto') {
-                    google.script.run.allocateThemesAutomatic(dr, hasHeader);
+                const flow = document.getElementById('flow').value;
+
+                let fn;
+                if (mode === 'auto') {
+                    if (flow === 'allocate') {
+                        fn = google.script.run.allocateThemesAutomatic;
+                    } else if (flow === 'matrix') {
+                        fn = google.script.run.matrixThemesAutomatic;
+                    } else {
+                        fn = google.script.run.similarityMatrixThemesAutomatic;
+                    }
+                    fn(dr, hasHeader);
+                } else if (mode === 'set') {
+                    const setName = document.getElementById('setSelect').value;
+                    if (!setName) {
+                        M.toast({ html: 'Please select a theme set' });
+                        return;
+                    }
+                    if (flow === 'allocate') {
+                        fn = google.script.run.allocateThemesFromSet;
+                    } else if (flow === 'matrix') {
+                        fn = google.script.run.matrixThemesFromSet;
+                    } else {
+                        fn = google.script.run.similarityMatrixThemesFromSet;
+                    }
+                    fn(dr, setName, hasHeader);
                 } else {
-                    google.script.run.allocateThemesFromSet(dr, mode, hasHeader);
+                    const sheetName = document.getElementById('sheetSelect').value;
+                    if (!sheetName) {
+                        M.toast({ html: 'Please select a sheet' });
+                        return;
+                    }
+                    if (flow === 'allocate') {
+                        fn = google.script.run.allocateThemesFromSheet;
+                    } else if (flow === 'matrix') {
+                        fn = google.script.run.matrixThemesFromSheet;
+                    } else {
+                        fn = google.script.run.similarityMatrixThemesFromSheet;
+                    }
+                    fn(dr, sheetName, hasHeader);
                 }
                 google.script.host.close();
             }

--- a/packages/sheets/src/Code.ts
+++ b/packages/sheets/src/Code.ts
@@ -13,8 +13,11 @@ import { splitIntoTokensFlow } from './splitIntoTokens';
 import { countWordsFlow } from './countWords';
 import { matrixThemesAutomatic } from './matrixThemesAutomatic';
 import { matrixThemesFromSet } from './matrixThemesFromSet';
+import { matrixThemesFromSheet } from './matrixThemesFromSheet';
 import { similarityMatrixThemesAutomatic } from './similarityMatrixThemesAutomatic';
 import { similarityMatrixThemesFromSet } from './similarityMatrixThemesFromSet';
+import { similarityMatrixThemesFromSheet } from './similarityMatrixThemesFromSheet';
+import { allocateThemesFromSheet } from './allocateThemesFromSheet';
 import { getFeed, getItem } from 'pulse-common/jobs';
 
 // Toggle verbose logging within the add-on
@@ -115,19 +118,18 @@ export function onOpen() {
         const themesMenu = ui
             .createMenu('Themes')
             .addItem('Generate', 'clickGenerateThemes')
-            .addItem('Allocate', 'clickAllocateThemes')
-            .addItem('Manage', 'showManageThemesDialog');
+            .addItem('Single Code', 'clickAllocateThemes')
+            .addItem('Multi Code', 'clickMatrixThemes')
+            .addItem('Similarity Scores', 'clickSimilarityScores')
+            .addSeparator()
+            .addItem('Theme Sets', 'showManageThemesDialog');
         pulseMenu.addSubMenu(themesMenu);
-        const advancedMenu = ui
-            .createMenu('Advanced')
+        const textTools = ui
+            .createMenu('Text Tools')
             .addItem('Split Sentences', 'splitSentencesCurrent')
             .addItem('Split Tokens', 'splitTokensCurrent')
-            .addItem('Count Words', 'countWordsCurrent')
-            .addItem('Matrix Allocate', 'matrixThemesAutomaticCurrent')
-            .addItem('Matrix From Set', 'matrixThemesFromSetPrompt')
-            .addItem('Similarity Matrix', 'similarityMatrixThemesAutomaticCurrent')
-            .addItem('Similarity From Set', 'similarityMatrixThemesFromSetPrompt');
-        pulseMenu.addSubMenu(advancedMenu);
+            .addItem('Count Words', 'countWordsCurrent');
+        pulseMenu.addSubMenu(textTools);
         pulseMenu.addSeparator();
     }
     // Always include settings
@@ -147,6 +149,14 @@ export function clickGenerateThemes() {
  */
 export function clickAllocateThemes() {
     showInputRangeDialog("allocation");
+}
+
+export function clickMatrixThemes() {
+    showInputRangeDialog('matrix');
+}
+
+export function clickSimilarityScores() {
+    showInputRangeDialog('similarity');
 }
 /**
  * Prompts the user to select the input range for sentiment analysis.
@@ -255,6 +265,20 @@ export function submitSelectedInputRangeForGeneration(
     return debouncedThemeGenerationRouting(dataRange, mode, hasHeader);
 }
 
+export function submitSelectedInputRangeForMatrix(
+    dataRange: string,
+    hasHeader = false,
+) {
+    matrixThemesWithRange(dataRange, hasHeader);
+}
+
+export function submitSelectedInputRangeForSimilarity(
+    dataRange: string,
+    hasHeader = false,
+) {
+    similarityMatrixWithRange(dataRange, hasHeader);
+}
+
 /**
  * Callback after input range is selected; opens dialog to choose allocation mode.
  * 
@@ -266,7 +290,21 @@ export function allocateThemesWithRange(
     dataRange: string,
     hasHeader = false,
 ) {
-    showAllocationModeDialog(dataRange, hasHeader);
+    showAllocationModeDialog(dataRange, hasHeader, 'allocate');
+}
+
+export function matrixThemesWithRange(
+    dataRange: string,
+    hasHeader = false,
+) {
+    showAllocationModeDialog(dataRange, hasHeader, 'matrix');
+}
+
+export function similarityMatrixWithRange(
+    dataRange: string,
+    hasHeader = false,
+) {
+    showAllocationModeDialog(dataRange, hasHeader, 'similarity');
 }
 /**
  * Save a manually created theme set.
@@ -393,5 +431,8 @@ export { splitIntoTokensFlow } from './splitIntoTokens'
 export { countWordsFlow } from './countWords'
 export { matrixThemesAutomatic } from './matrixThemesAutomatic'
 export { matrixThemesFromSet } from './matrixThemesFromSet'
+export { matrixThemesFromSheet } from './matrixThemesFromSheet'
 export { similarityMatrixThemesAutomatic } from './similarityMatrixThemesAutomatic'
 export { similarityMatrixThemesFromSet } from './similarityMatrixThemesFromSet'
+export { similarityMatrixThemesFromSheet } from './similarityMatrixThemesFromSheet'
+export { allocateThemesFromSheet } from './allocateThemesFromSheet'

--- a/packages/sheets/src/InputRangeDialog.html
+++ b/packages/sheets/src/InputRangeDialog.html
@@ -54,12 +54,24 @@
               M.toast({ html: 'Error: ' + err.message });
             })
             .analyzeSentimentFlow(dataRange, hasHeader);
-        } else {
+        } else if (mode === 'generation' || mode === 'allocation') {
           google.script.run
             .withFailureHandler(function (err) {
               M.toast({ html: 'Error: ' + err.message });
             })
             .submitSelectedInputRangeForGeneration(dataRange, mode, hasHeader);
+        } else if (mode === 'matrix') {
+          google.script.run
+            .withFailureHandler(function (err) {
+              M.toast({ html: 'Error: ' + err.message });
+            })
+            .submitSelectedInputRangeForMatrix(dataRange, hasHeader);
+        } else if (mode === 'similarity') {
+          google.script.run
+            .withFailureHandler(function (err) {
+              M.toast({ html: 'Error: ' + err.message });
+            })
+            .submitSelectedInputRangeForSimilarity(dataRange, hasHeader);
         }
         google.script.host.close();
       }

--- a/packages/sheets/src/allocateThemesFromSheet.ts
+++ b/packages/sheets/src/allocateThemesFromSheet.ts
@@ -1,0 +1,66 @@
+import { allocateThemes } from 'pulse-common/api';
+import { extractInputsWithHeader, expandWithBlankRows } from 'pulse-common/dataUtils';
+import { feedToast } from './feedToast';
+import { readThemesFromSheet } from './readThemesFromSheet';
+import { getFeed, updateItem } from 'pulse-common/jobs';
+
+export async function allocateThemesFromSheet(
+    dataRange: string,
+    sheetName: string,
+    hasHeader = false,
+) {
+    const ui = SpreadsheetApp.getUi();
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+
+    let dataRangeObj: GoogleAppsScript.Spreadsheet.Range;
+    try {
+        dataRangeObj = ss.getRange(dataRange);
+    } catch (e) {
+        ui.alert('Error reading data range: ' + e.toString());
+        return;
+    }
+    const values = dataRangeObj.getValues();
+
+    const { inputs, positions } = extractInputsWithHeader(values, {
+        rowOffset: dataRangeObj.getRow(),
+        colOffset: dataRangeObj.getColumn(),
+        hasHeader,
+    });
+
+    let themes;
+    try {
+        themes = readThemesFromSheet(sheetName);
+    } catch (err) {
+        ui.alert((err as Error).message);
+        return;
+    }
+
+    const dataSheet = dataRangeObj.getSheet();
+
+    const allocations = await allocateThemes(inputs, themes, {
+        fast: false,
+        onProgress: (message: string) => {
+            feedToast(message);
+        },
+    });
+
+    const labels = allocations.map((a) => (a.belowThreshold ? '' : a.theme.label));
+    const expanded = expandWithBlankRows(labels, positions);
+    const startRow = Math.min(...positions.map((p) => p.row));
+    const col = dataRangeObj.getColumn() + 1;
+    dataSheet.getRange(startRow, col, expanded.length, 1).setValues(expanded.map((l) => [l]));
+
+    feedToast('Theme allocation complete');
+
+    const feed = getFeed();
+    const last = feed[feed.length - 1];
+    if (last) {
+        updateItem({
+            jobId: last.jobId,
+            onClick: () => {
+                SpreadsheetApp.setActiveSheet(dataSheet);
+            },
+            sheetName: dataSheet.getName(),
+        });
+    }
+}

--- a/packages/sheets/src/matrixThemesFromSheet.ts
+++ b/packages/sheets/src/matrixThemesFromSheet.ts
@@ -1,0 +1,81 @@
+import { multiCode, ShortTheme } from 'pulse-common/themes';
+import { extractInputsWithHeader, expandWithBlankRows } from 'pulse-common/dataUtils';
+import { maybeActivateSheet } from './maybeActivateSheet';
+import { feedToast } from './feedToast';
+import { getFeed, updateItem } from 'pulse-common/jobs';
+import { readThemesFromSheet } from './readThemesFromSheet';
+
+const THRESHOLD = 0.4;
+
+export async function matrixThemesFromSheet(
+    dataRange: string,
+    sheetName: string,
+    hasHeader = false,
+) {
+    const ui = SpreadsheetApp.getUi();
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const startTime = Date.now();
+
+    let rangeObj: GoogleAppsScript.Spreadsheet.Range;
+    try {
+        rangeObj = ss.getRange(dataRange);
+    } catch (e) {
+        ui.alert('Error reading data range: ' + e.toString());
+        return;
+    }
+    const values = rangeObj.getValues();
+    const { header, inputs, positions } = extractInputsWithHeader(values, {
+        rowOffset: rangeObj.getRow(),
+        colOffset: rangeObj.getColumn(),
+        hasHeader,
+    });
+
+    let themes: ShortTheme[];
+    try {
+        themes = readThemesFromSheet(sheetName) as ShortTheme[];
+    } catch (err) {
+        ui.alert((err as Error).message);
+        return;
+    }
+
+    const expanded = expandWithBlankRows(inputs, positions);
+    const matrix = await multiCode(expanded, themes, {
+        fast: false,
+        threshold: THRESHOLD,
+        onProgress: (m) => feedToast(m),
+    });
+
+    const sheet = writeMatrix(matrix, expanded, themes, header);
+    maybeActivateSheet(sheet, startTime);
+
+    feedToast('Matrix generation complete');
+
+    const feed = getFeed();
+    const last = feed[feed.length - 1];
+    if (last) {
+        updateItem({
+            jobId: last.jobId,
+            onClick: () => {
+                SpreadsheetApp.setActiveSheet(sheet);
+            },
+            sheetName: sheet.getName(),
+        });
+    }
+}
+
+function writeMatrix(
+    matrix: (number | boolean)[][],
+    inputs: string[],
+    themes: ShortTheme[],
+    header?: string,
+): GoogleAppsScript.Spreadsheet.Sheet {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const sheet = ss.insertSheet(`Allocation_${Date.now()}`);
+    const headerRow = [header ?? 'Text', ...themes.map((t) => t.label)];
+    sheet.getRange(1, 1, 1, headerRow.length).setValues([headerRow]);
+    const rows = matrix.map((row, i) => [inputs[i], ...row]);
+    if (rows.length > 0) {
+        sheet.getRange(2, 1, rows.length, rows[0].length).setValues(rows);
+    }
+    return sheet;
+}

--- a/packages/sheets/src/readThemesFromSheet.ts
+++ b/packages/sheets/src/readThemesFromSheet.ts
@@ -1,0 +1,25 @@
+export function readThemesFromSheet(sheetName: string): { label: string; representatives: string[] }[] {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const sheet = ss.getSheetByName(sheetName);
+    if (!sheet) {
+        throw new Error('Sheet not found: ' + sheetName);
+    }
+    const values = sheet.getDataRange().getValues();
+    if (values.length <= 1) {
+        throw new Error('Sheet "' + sheetName + '" has no data');
+    }
+    const rows = values.slice(1);
+    const themes: { label: string; representatives: string[] }[] = [];
+    rows.forEach((row) => {
+        const label = row[0];
+        const rep1 = row[3];
+        const rep2 = row[4];
+        if (label) {
+            const reps: string[] = [];
+            if (rep1) reps.push(String(rep1));
+            if (rep2) reps.push(String(rep2));
+            themes.push({ label: String(label), representatives: reps });
+        }
+    });
+    return themes;
+}

--- a/packages/sheets/src/showAllocationModeDialog.ts
+++ b/packages/sheets/src/showAllocationModeDialog.ts
@@ -7,16 +7,22 @@ import { getThemeSets } from 'pulse-common';
 export async function showAllocationModeDialog(
     dataRange: string,
     hasHeader = false,
+    flow: 'allocate' | 'matrix' | 'similarity' = 'allocate',
 ) {
     const ui = SpreadsheetApp.getUi();
     const template = HtmlService.createTemplateFromFile('AllocationModeDialog');
     template.dataRange = dataRange;
     template.hasHeader = hasHeader;
+    template.flow = flow;
     // Pass existing saved theme set names to the dialog template
     const themeSet = await getThemeSets();
     template.themeSetNames = themeSet.map(function (s) {
         return s.name;
     });
+    const sheetNames = SpreadsheetApp.getActiveSpreadsheet()
+        .getSheets()
+        .map((s) => s.getName());
+    template.sheetNames = sheetNames;
     const html = template.evaluate().setWidth(400).setHeight(200);
     ui.showModelessDialog(html, 'Theme Allocation Mode');
 }

--- a/packages/sheets/src/showInputRangeDialog.ts
+++ b/packages/sheets/src/showInputRangeDialog.ts
@@ -7,7 +7,9 @@ import { getActiveRangeA1Notation } from './Code';
  * Opens a dialog to confirm or change the input data range.
  * @param mode 'allocation', 'generation', or 'sentiment'
  */
-export function showInputRangeDialog(mode: 'allocation' | 'generation' | 'sentiment') {
+export function showInputRangeDialog(
+    mode: 'allocation' | 'generation' | 'sentiment' | 'matrix' | 'similarity',
+) {
     const ui = SpreadsheetApp.getUi();
     const template = HtmlService.createTemplateFromFile('InputRangeDialog');
     template.dataRange = getActiveRangeA1Notation();

--- a/packages/sheets/src/similarityMatrixThemesFromSheet.ts
+++ b/packages/sheets/src/similarityMatrixThemesFromSheet.ts
@@ -1,0 +1,79 @@
+import { splitSimilarityMatrix, ShortTheme } from 'pulse-common/themes';
+import { extractInputsWithHeader, expandWithBlankRows } from 'pulse-common/dataUtils';
+import { maybeActivateSheet } from './maybeActivateSheet';
+import { feedToast } from './feedToast';
+import { getFeed, updateItem } from 'pulse-common/jobs';
+import { readThemesFromSheet } from './readThemesFromSheet';
+
+export async function similarityMatrixThemesFromSheet(
+    dataRange: string,
+    sheetName: string,
+    hasHeader = false,
+) {
+    const ui = SpreadsheetApp.getUi();
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const startTime = Date.now();
+
+    let rangeObj: GoogleAppsScript.Spreadsheet.Range;
+    try {
+        rangeObj = ss.getRange(dataRange);
+    } catch (e) {
+        ui.alert('Error reading data range: ' + e.toString());
+        return;
+    }
+    const values = rangeObj.getValues();
+    const { header, inputs, positions } = extractInputsWithHeader(values, {
+        rowOffset: rangeObj.getRow(),
+        colOffset: rangeObj.getColumn(),
+        hasHeader,
+    });
+
+    let themes: ShortTheme[];
+    try {
+        themes = readThemesFromSheet(sheetName) as ShortTheme[];
+    } catch (err) {
+        ui.alert((err as Error).message);
+        return;
+    }
+
+    const expanded = expandWithBlankRows(inputs, positions);
+    const matrix = await splitSimilarityMatrix(expanded, themes, {
+        fast: false,
+        normalize: false,
+        onProgress: (m) => feedToast(m),
+    });
+
+    const sheet = writeMatrix(matrix, expanded, themes, header);
+    maybeActivateSheet(sheet, startTime);
+
+    feedToast('Similarity matrix complete');
+
+    const feed = getFeed();
+    const last = feed[feed.length - 1];
+    if (last) {
+        updateItem({
+            jobId: last.jobId,
+            onClick: () => {
+                SpreadsheetApp.setActiveSheet(sheet);
+            },
+            sheetName: sheet.getName(),
+        });
+    }
+}
+
+function writeMatrix(
+    matrix: number[][],
+    inputs: string[],
+    themes: ShortTheme[],
+    header?: string,
+): GoogleAppsScript.Spreadsheet.Sheet {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const sheet = ss.insertSheet(`Similarity_${Date.now()}`);
+    const headerRow = [header ?? 'Text', ...themes.map((t) => t.label)];
+    sheet.getRange(1, 1, 1, headerRow.length).setValues([headerRow]);
+    const rows = matrix.map((row, i) => [inputs[i], ...row]);
+    if (rows.length > 0) {
+        sheet.getRange(2, 1, rows.length, rows[0].length).setValues(rows);
+    }
+    return sheet;
+}

--- a/packages/sheets/src/updateMenu.ts
+++ b/packages/sheets/src/updateMenu.ts
@@ -11,19 +11,18 @@ export function updateMenu() {
         const themesMenu = ui
             .createMenu('Themes')
             .addItem('Generate', 'clickGenerateThemes')
-            .addItem('Allocate', 'clickAllocateThemes')
-            .addItem('Manage', 'showManageThemesDialog');
+            .addItem('Single Code', 'clickAllocateThemes')
+            .addItem('Multi Code', 'clickMatrixThemes')
+            .addItem('Similarity Scores', 'clickSimilarityScores')
+            .addSeparator()
+            .addItem('Theme Sets', 'showManageThemesDialog');
         pulseMenu.addSubMenu(themesMenu);
-        const adv = ui
-            .createMenu('Advanced')
+        const textTools = ui
+            .createMenu('Text Tools')
             .addItem('Split Sentences', 'splitSentencesCurrent')
             .addItem('Split Tokens', 'splitTokensCurrent')
-            .addItem('Count Words', 'countWordsCurrent')
-            .addItem('Matrix Allocate', 'matrixThemesAutomaticCurrent')
-            .addItem('Matrix From Set', 'matrixThemesFromSetPrompt')
-            .addItem('Similarity Matrix', 'similarityMatrixThemesAutomaticCurrent')
-            .addItem('Similarity From Set', 'similarityMatrixThemesFromSetPrompt');
-        pulseMenu.addSubMenu(adv);
+            .addItem('Count Words', 'countWordsCurrent');
+        pulseMenu.addSubMenu(textTools);
         pulseMenu.addSeparator();
     }
     pulseMenu.addItem('Feed', 'showFeedSidebar');


### PR DESCRIPTION
## Summary
- reorganize `Themes` menu and add `Text Tools`
- add dialog to choose theme source including set and sheet options
- implement allocation, matrix, and similarity flows from sheet
- support matrix and similarity modes in range dialog

## Testing
- `bun run lint` *(fails: No files matching pattern and other lint errors)*
- `bun run typecheck`
- `bun run test`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_b_6883ae75a8f08329a31a8cb1316abd9d